### PR TITLE
include unistd.h for linux, needed for usleep

### DIFF
--- a/src/chuck_globals.cpp
+++ b/src/chuck_globals.cpp
@@ -67,6 +67,7 @@ t_CKUINT g_watchdog_countermeasure_priority = 10;
 t_CKUINT g_watchdog_countermeasure_priority = THREAD_PRIORITY_LOWEST;
 #else
 t_CKUINT g_watchdog_countermeasure_priority = 0;
+#include <unistd.h>
 #endif
 // watchdog timeout
 t_CKFLOAT g_watchdog_timeout = 0.5;


### PR DESCRIPTION
My last pull req was regressed with a recent commit, and it broke my Linux build again. Ubuntu Trusty, g++ 4.8.4.

The issue is that usleep is BSD deprecated, and so requires include unistd.h. One could replace it with non-deprecated nanosleep, but it looks like the flaws of usleep don't affect this use.

See the first answer here: https://stackoverflow.com/questions/10976176/c-error-sleep-was-not-declared-in-this-scope

I placed the include in a linux-only ifdef so it shouldn't affect other OSes. OTOH, it's not near the other includes anymore, which is stylistically bad.