### PR TITLE
Document machine shreds

### DIFF
--- a/doc/manual/chapters/chuck_stdlib.tex
+++ b/doc/manual/chapters/chuck_stdlib.tex
@@ -165,7 +165,7 @@ returns the VMs current list of shred IDs
 }
 
 \chuckmultifunction{ void crash ( );}{
-iterally causes the VM to crash. the very last resort; use with care. Thanks.
+literally causes the VM to crash. the very last resort; use with care. Thanks.
 }
 
 

--- a/doc/manual/chapters/chuck_stdlib.tex
+++ b/doc/manual/chapters/chuck_stdlib.tex
@@ -160,6 +160,10 @@ same functionality as status/\^ \\
 (see example/status.ck)
 }
 
+\chuckmultifunction{ int[] shreds ( );}{
+returns the VMs current list of shred IDs
+}
+
 \chuckmultifunction{ void crash ( );}{
 iterally causes the VM to crash. the very last resort; use with care. Thanks.
 }


### PR DESCRIPTION
Adds missing documentation for the std lib `Machine.shreds()` function.

The `l` from `literally` in the line below seemed to be missing from this copy of the documentation as well, so I added it in a separate commit in this PR.