### PR TITLE
Improve Array Size Method Docs

### DIFF
--- a/doc/manual/chapters/chuck_array.tex
+++ b/doc/manual/chapters/chuck_array.tex
@@ -45,6 +45,14 @@ If you only want an array of object references:
     // array of null object references
     Object @ group[10];
 \end{verbatim}
+
+The size method returns the total count of elements in an array. This is sometimes called `length' in other languages.
+\begin{verbatim}
+    [ 1, 2, 8, 1 ] @=> int foo[];
+    foo.size(); // returns 4
+    foo.cap(); // also returns 4, as it is an alias of the size method.
+\end{verbatim}
+
 Check here more information on object declaration and instantation in Chuck.
 
 The above examples are 1-dimensional arrays (or vectors). Coming up next are multi-dimensional arrays!
@@ -86,7 +94,7 @@ Looping over the elements of an array:
     [ 1, 2, 3, 4, 5, 6 ] @=> float foo[];
 
     // loop over the entire array
-    for( 0 => int i; i < foo.cap(); i++ )
+    for( 0 => int i; i < foo.size(); i++ )
     {
         // do something (debug print)
         <<< foo[i] >>>;
@@ -104,7 +112,7 @@ Accessing multi-dimensional array:
 
 If the index exceeds the bounds of the array in any dimension, an exception is issued and the current shred is halted.
 \begin{verbatim}
-    // array capacity is 5
+    // array size is 5
     int foo[5];
 
     // this should cause ArrayOutOfBoundsException
@@ -149,7 +157,7 @@ a longer program: otf\_06.ck from examples:
 
 Any array can be used also as an associative array, indexed on strings. Once the regular array is instantiated, no further work has to be done to make it associative as well - just start using it as such.
 \begin{verbatim}
-    // declare regular array (capacity doesn't matter so much)
+    // declare regular array (size doesn't matter so much)
     float foo[4];
 
     // use as integer-indexed array
@@ -180,9 +188,9 @@ It is important to note (again), that the address space of the integer portion a
     <<< foo[0], foo["0"] >>>;
 \end{verbatim}
 
-The capacity of an array relates only to the integer portion of it. An array with an integer portion of capacity 0, for example, can still have any number of associative indexes.
+The size of an array relates only to the integer portion of it. An array with an integer portion of size 0, for example, can still have any number of associative indexes.
 \begin{verbatim}
-    // declare array of 0 capacity
+    // declare array of 0 size
     int foo[0];
 
     // put something in element "here"
@@ -224,7 +232,7 @@ Note: The associative capacity of an array is not defined, so objects used in th
 Arrays are objects. So when we declare an array, we are actually (1) declaring a reference to array (reference variable) and (2) instantiating a new array and reference assigned to the variable. A (null) reference is a reference variable that points to no
  object or null. A null reference to an array can be created in this fasion:
 \begin{verbatim}
-    // declare array reference (by not specifying a capacity)
+    // declare array reference (by not specifying a size)
     int foo[];
 
     // we can now assign any int[] to foo
@@ -240,7 +248,7 @@ This is also useful in declaring functions that have arrays as arguments or retu
     fun void print( int bar[] )
     {
         // print it
-        for( 0 => int i; i < bar.cap(); i++ )
+        for( 0 => int i; i < bar.size(); i++ )
             <<< bar[0] >>>;
     }
 

--- a/src/examples/analysis/tracking/Tracking.ck
+++ b/src/examples/analysis/tracking/Tracking.ck
@@ -37,7 +37,7 @@ while( true )
     
     // find peak
     0 => float max; float where;
-    for( int i; i < blob.fvals().cap()/8; i++ )
+    for( int i; i < blob.fvals().size()/8; i++ )
     {
         // compare
         if( blob.fvals()[i] > max )

--- a/src/examples/analysis/tracking/harm.ck
+++ b/src/examples/analysis/tracking/harm.ck
@@ -59,7 +59,7 @@ fun void smack_handler()
         Smacking.the_event => now;
         
         // choose random interval
-        harms[Math.random2(0,harms.cap()-1)] => the_harm;
+        harms[Math.random2(0,harms.size()-1)] => the_harm;
         // set freq
         Tracking.the_freq * Math.pow(1.059, the_harm) => target_freq;
         // print

--- a/src/examples/analysis/tracking/pitch-fifth.ck
+++ b/src/examples/analysis/tracking/pitch-fifth.ck
@@ -33,7 +33,7 @@ while( true )
     
     // find peak
     0 => float max; float where;
-    for( int i; i < blob.fvals().cap()/8; i++ )
+    for( int i; i < blob.fvals().size()/8; i++ )
     {
         // compare
         if( blob.fvals()[i] > max )

--- a/src/examples/analysis/tracking/pitch-seventh.ck
+++ b/src/examples/analysis/tracking/pitch-seventh.ck
@@ -33,7 +33,7 @@ while( true )
     
     // find peak
     0 => float max; float where;
-    for( int i; i < blob.fvals().cap(); i++ )
+    for( int i; i < blob.fvals().size(); i++ )
     {
         // compare
         if( blob.fvals()[i] > max )

--- a/src/examples/analysis/tracking/pitch-third.ck
+++ b/src/examples/analysis/tracking/pitch-third.ck
@@ -33,7 +33,7 @@ while( true )
     
     // find peak
     0 => float max; float where;
-    for( int i; i < blob.fvals().cap(); i++ )
+    for( int i; i < blob.fvals().size(); i++ )
     {
         // compare
         if( blob.fvals()[i] > max )

--- a/src/examples/analysis/tracking/pitch-track.ck
+++ b/src/examples/analysis/tracking/pitch-track.ck
@@ -38,7 +38,7 @@ while( true )
     
     // find peak
     0 => float max; int where;
-    for( int i; i < blob.fvals().cap(); i++ )
+    for( int i; i < blob.fvals().size(); i++ )
     {
         // compare
         if( blob.fvals()[i] > max )

--- a/src/examples/basic/bar.ck
+++ b/src/examples/basic/bar.ck
@@ -10,7 +10,7 @@ while( true )
 {
     // change parameters here
     Std.mtof( 45 + Math.random2(0,0) * 12 +
-        hi[Math.random2(0,hi.cap()-1)] ) => s.freq;
+        hi[Math.random2(0,hi.size()-1)] ) => s.freq;
 
     // different rate
     200::ms => now;

--- a/src/examples/basic/blit.ck
+++ b/src/examples/basic/blit.ck
@@ -5,7 +5,7 @@ Blit s => JCRev r => dac;
 
 // an array
 [ 0, 2, 4, 7, 9, 11 ] @=> int hi[];
-// <<< hi.size(), hi.cap() >>>;
+// <<< hi.size() >>>;
 // <<< hi[0], hi[1], hi[2], hi[3], hi[4], hi[5] >>>;
 
 // infinite time loop

--- a/src/examples/basic/blit2.ck
+++ b/src/examples/basic/blit2.ck
@@ -14,7 +14,7 @@ while( true )
 {
     // frequency
     Std.mtof( 33 + Math.random2(0,3) * 12 +
-        hi[Math.random2(0,hi.cap()-1)] ) => s.freq;
+        hi[Math.random2(0,hi.size()-1)] ) => s.freq;
 
     // harmonics
     Math.random2( 1, 5 ) => s.harmonics;

--- a/src/examples/basic/foo.ck
+++ b/src/examples/basic/foo.ck
@@ -12,6 +12,6 @@ SinOsc s => JCRev r => dac;
 while( true )
 {
     Std.mtof( 45 + Math.random2(0,3) * 12 +
-        hi[Math.random2(0,hi.cap()-1)] ) => s.freq;
+        hi[Math.random2(0,hi.size()-1)] ) => s.freq;
     100::ms => now;
 }

--- a/src/examples/basic/foo2.ck
+++ b/src/examples/basic/foo2.ck
@@ -21,7 +21,7 @@ spork ~ dopan();
 while( true )
 {
     Std.mtof( 33 + Math.random2(0,3) * 12 +
-        hi[Math.random2(0,hi.cap()-1)] ) => s.freq;
+        hi[Math.random2(0,hi.size()-1)] ) => s.freq;
     120::ms => now;
 }
 

--- a/src/examples/class/try.ck
+++ b/src/examples/class/try.ck
@@ -39,7 +39,7 @@ while( true )
 {
     // trigger
     45 + Math.random2(0,3) * 12 + 
-         hi[Math.random2(0,hi.cap()-1)] => imp.t;
+         hi[Math.random2(0,hi.size()-1)] => imp.t;
     // let time pass
     195::ms => now;
     // close the envelope

--- a/src/examples/deep/unclap.ck
+++ b/src/examples/deep/unclap.ck
@@ -31,14 +31,14 @@ fun void clap( SndBuf buffy, int max, float factor )
     for( ; true; shifts++ )
     {
         // one measure
-        for( 0 => int count; count < seq.cap(); count++ )
+        for( 0 => int count; count < seq.size(); count++ )
         {
             // set gain
             seq[count] * 2 => buffy.gain;
             // clap!
             0 => buffy.pos;
             // let time go by
-            if( !max || shifts < max || count != (seq.cap() - 1) )
+            if( !max || shifts < max || count != (seq.size() - 1) )
                 seq[count]::quarter => now;
             else
             {

--- a/src/examples/event/clix.ck
+++ b/src/examples/event/clix.ck
@@ -27,7 +27,7 @@ Impulse i => BiQuad f => Envelope e => JCRev r => dac;
   0.4, 0.1, 0.3, 0.2, 0.3, 0.1, 0.2, 0.1 ] @=> float mygains[];
 
 // capacity
-mygains.cap() => int N;
+mygains.size() => int N;
 // total period
 N * T => dur period;
 

--- a/src/examples/event/clix2.ck
+++ b/src/examples/event/clix2.ck
@@ -27,7 +27,7 @@ Impulse i => BiQuad f => Envelope e => JCRev r;
   0.4, 0.1, 0.3, 0.2, 0.3, 0.1, 0.2, 0.1 ] @=> float mygains[];
 
 // capacity
-mygains.cap() => int N;
+mygains.size() => int N;
 // period duration
 N * T => dur period;
 

--- a/src/examples/event/clix3.ck
+++ b/src/examples/event/clix3.ck
@@ -27,7 +27,7 @@ Impulse i => BiQuad f => Envelope e => JCRev r => dac;
   0.4, 0.1, 0.3, 0.2, 0.3, 0.1, 0.2, 0.1 ] @=> float mygains[];
 
 // capacity
-mygains.cap() => int N;
+mygains.size() => int N;
 // total period
 N * T => dur period;
 

--- a/src/examples/extend/chubgraph.ck
+++ b/src/examples/extend/chubgraph.ck
@@ -33,11 +33,11 @@ class MyString extends Chubgraph
 }
 
 MyString s[3];
-for(int i; i < s.cap(); i++) s[i] => dac;
+for(int i; i < s.size(); i++) s[i] => dac;
 
 while( true )
 {
-    for( int i; i < s.cap(); i++ )
+    for( int i; i < s.size(); i++ )
     {
         Math.random2( 60,72 ) => Std.mtof => s[i].freq;
         spork ~ s[i].pluck();

--- a/src/examples/hanoi++.ck
+++ b/src/examples/hanoi++.ck
@@ -27,7 +27,7 @@ me.dir() + "/data/kick.wav" => pegs[2].read;
 me.dir() + "/data/snare-hop.wav" => pegs[3].read;
 
 // connect to gain
-for( 1 => int i; i < pegs.cap(); i++ )
+for( 1 => int i; i < pegs.size(); i++ )
     pegs[i] => g;
 
 // the hanoi

--- a/src/examples/midi/gomidi2.ck
+++ b/src/examples/midi/gomidi2.ck
@@ -10,7 +10,7 @@ MidiIn min[16];
 int devices;
 
 // loop
-for( int i; i < min.cap(); i++ )
+for( int i; i < min.size(); i++ )
 {
     // no print err
     min[i].printerr( 0 );

--- a/src/examples/midi/playmidi.ck
+++ b/src/examples/midi/playmidi.ck
@@ -33,7 +33,7 @@ fun void track(int t)
 {
     // hack polyphony
     Mandolin s[4];
-    for(int i; i < s.cap(); i++) s[i] => reverb;
+    for(int i; i < s.size(); i++) s[i] => reverb;
     
     int v;
     
@@ -47,7 +47,7 @@ fun void track(int t)
             msg.data2 => Std.mtof => s[v].freq;
             msg.data3/127.0 => s[v].noteOn;
                         
-            (v+1)%s.cap() => v;
+            (v+1)%s.size() => v;
         }
     }
     

--- a/src/examples/serial/byte.ck
+++ b/src/examples/serial/byte.ck
@@ -1,7 +1,7 @@
 
 SerialIO.list() @=> string list[];
 
-for(int i; i < list.cap(); i++)
+for(int i; i < list.size(); i++)
 {
     chout <= i <= ": " <= list[i] <= IO.newline();
 }

--- a/src/examples/serial/bytes.ck
+++ b/src/examples/serial/bytes.ck
@@ -1,7 +1,7 @@
 
 SerialIO.list() @=> string list[];
 
-for(int i; i < list.cap(); i++)
+for(int i; i < list.size(); i++)
 {
     chout <= i <= ": " <= list[i] <= IO.newline();
 }
@@ -14,7 +14,7 @@ while(true)
     cereal.onBytes(4) => now;
     cereal.getBytes() @=> int bytes[];
     chout <= "bytes: ";
-    for(int i; i < bytes.cap(); i++)
+    for(int i; i < bytes.size(); i++)
     {
         chout <= bytes[i] <= " ";
     }

--- a/src/examples/serial/ints-bin.ck
+++ b/src/examples/serial/ints-bin.ck
@@ -1,7 +1,7 @@
 
 SerialIO.list() @=> string list[];
 
-for(int i; i < list.cap(); i++)
+for(int i; i < list.size(); i++)
 {
     chout <= i <= ": " <= list[i] <= IO.newline();
 }

--- a/src/examples/serial/ints.ck
+++ b/src/examples/serial/ints.ck
@@ -1,7 +1,7 @@
 
 SerialIO.list() @=> string list[];
 
-for(int i; i < list.cap(); i++)
+for(int i; i < list.size(); i++)
 {
     chout <= i <= ": " <= list[i] <= IO.newline();
 }
@@ -17,7 +17,7 @@ while(true)
     cereal.onInts(2) => now;
     cereal.getInts() @=> int ints[];
     chout <= "ints: ";
-    for(int i; i < ints.cap(); i++)
+    for(int i; i < ints.size(); i++)
     {
         chout <= ints[i] <= " ";
     }

--- a/src/examples/serial/lines.ck
+++ b/src/examples/serial/lines.ck
@@ -1,7 +1,7 @@
 
 SerialIO.list() @=> string list[];
 
-for(int i; i < list.cap(); i++)
+for(int i; i < list.size(); i++)
 {
     chout <= i <= ": " <= list[i] <= IO.newline();
 }
@@ -10,7 +10,7 @@ for(int i; i < list.cap(); i++)
 0 => int device;
 if(me.args()) me.arg(0) => Std.atoi => device;
 
-if(device >= list.cap())
+if(device >= list.size())
 {
     cherr <= "serial device #" <= device <= " not available\n";
     me.exit(); 

--- a/src/examples/serial/list.ck
+++ b/src/examples/serial/list.ck
@@ -1,7 +1,7 @@
 
 SerialIO.list() @=> string list[];
 
-for(int i; i < list.cap(); i++)
+for(int i; i < list.size(); i++)
 {
     chout <= i <= ": " <= list[i] <= IO.newline();
 }

--- a/src/examples/serial/write-bytes.ck
+++ b/src/examples/serial/write-bytes.ck
@@ -3,7 +3,7 @@
 SerialIO.list() @=> string list[];
 
 // no serial devices available
-if(list.cap() == 0)
+if(list.size() == 0)
 {
     cherr <= "no serial devices available\n";
     me.exit(); 
@@ -11,7 +11,7 @@ if(list.cap() == 0)
 
 // print list of serial devices
 chout <= "Available devices\n";
-for(int i; i < list.cap(); i++)
+for(int i; i < list.size(); i++)
 {
     chout <= i <= ": " <= list[i] <= IO.newline();
 }
@@ -20,7 +20,7 @@ for(int i; i < list.cap(); i++)
 0 => int device;
 if(me.args()) me.arg(0) => Std.atoi => device;
 
-if(device >= list.cap())
+if(device >= list.size())
 {
     cherr <= "serial device #" <= device <= "not available\n";
     me.exit(); 

--- a/src/examples/serial/write.ck
+++ b/src/examples/serial/write.ck
@@ -3,7 +3,7 @@
 SerialIO.list() @=> string list[];
 
 // no serial devices available
-if(list.cap() == 0)
+if(list.size() == 0)
 {
     cherr <= "no serial devices available\n";
     me.exit(); 
@@ -11,7 +11,7 @@ if(list.cap() == 0)
 
 // print list of serial devices
 chout <= "Available devices\n";
-for(int i; i < list.cap(); i++)
+for(int i; i < list.size(); i++)
 {
     chout <= i <= ": " <= list[i] <= IO.newline();
 }
@@ -20,7 +20,7 @@ for(int i; i < list.cap(); i++)
 0 => int device;
 if(me.args()) me.arg(0) => Std.atoi => device;
 
-if(device >= list.cap())
+if(device >= list.size())
 {
 	cherr <= "serial device #" <= device <= "not available\n";
 	me.exit(); 

--- a/src/examples/stereo/array.ck
+++ b/src/examples/stereo/array.ck
@@ -8,7 +8,7 @@ SndBuf buf[32] => Pan2 pan[32] => NRev reverb[2] => dac;
 0.1 => reverb[0].mix;
 0.11 => reverb[1].mix;
 
-for(int i; i < buf.cap(); i++)
+for(int i; i < buf.size(); i++)
 {
     // load dope sound
     "special:dope" => buf[i].read;
@@ -20,9 +20,9 @@ for(int i; i < buf.cap(); i++)
 
 while(true)
 {
-    //Math.pow(2, Std.rand2f(-1.5, 1.5)) => buf[i%buf.cap()].rate;
-    Std.rand2f(-0.5,0.5) => pan[i%pan.cap()].pan;
-    0 => buf[i%buf.cap()].pos;
+    //Math.pow(2, Std.rand2f(-1.5, 1.5)) => buf[i%buf.size()].rate;
+    Std.rand2f(-0.5,0.5) => pan[i%pan.size()].pan;
+    0 => buf[i%buf.size()].pos;
     
     Std.rand2f(0.075, 0.125)::second => now;
     //0.5::second => now;

--- a/src/examples/stk/band-o-matic.ck
+++ b/src/examples/stk/band-o-matic.ck
@@ -52,7 +52,7 @@ while( true )
         0.5::second *  Math.random2(1,3) => now;
 
         // scale
-        scale[Math.random2(0, scale.cap()-1)] => int freq;
+        scale[Math.random2(0, scale.size()-1)] => int freq;
         Std.mtof( 21 + Math.random2(0,5) * 12 + freq ) => band.freq;
         // note: Math.randomf() returns value between 0 and 1
         if( Math.randomf() > 0.85 ) 

--- a/src/examples/stk/bandedwg.ck
+++ b/src/examples/stk/bandedwg.ck
@@ -16,7 +16,7 @@ while( true )
     Math.random2( 0, 3 ) => bwg.preset;
 
     // set freq
-    scale[Math.random2(0,scale.cap()-1)] => int winner;
+    scale[Math.random2(0,scale.size()-1)] => int winner;
     57 + Math.random2(0,2)*12 + winner => Std.mtof => bwg.freq;
 
     // print some parameters

--- a/src/examples/stk/bandedwg2.ck
+++ b/src/examples/stk/bandedwg2.ck
@@ -36,7 +36,7 @@ while( true )
     <<< "bow Pressure:", bwg.bowPressure() >>>;
 
     // set freq
-    scale[Math.random2(0,scale.cap()-1)] => int winner;
+    scale[Math.random2(0,scale.size()-1)] => int winner;
     57 + Math.random2(0,2)*12 + winner => Std.mtof => bwg.freq;
     // go
     .8 => bwg.noteOn;

--- a/src/examples/stk/blowbotl.ck
+++ b/src/examples/stk/blowbotl.ck
@@ -23,7 +23,7 @@ while( true )
     <<< "volume:", bottle.volume() >>>;
 
     // set freq
-    scale[Math.random2(0,scale.cap()-1)] + 57 => Std.mtof => bottle.freq;
+    scale[Math.random2(0,scale.size()-1)] + 57 => Std.mtof => bottle.freq;
     // go
     .8 => bottle.noteOn;
 

--- a/src/examples/stk/blowbotl2.ck
+++ b/src/examples/stk/blowbotl2.ck
@@ -31,7 +31,7 @@ while( true )
     bottle.controlChange( 128, volume );
 
     // set freq
-    scale[Math.random2(0,scale.cap()-1)] + 57 => Std.mtof => bottle.freq;
+    scale[Math.random2(0,scale.size()-1)] + 57 => Std.mtof => bottle.freq;
     // go
     .8 => bottle.noteOn;
 

--- a/src/examples/stk/blowhole.ck
+++ b/src/examples/stk/blowhole.ck
@@ -32,7 +32,7 @@ while( true )
   }
 
   // set freq
-  scale[Math.random2(0,scale.cap()-1)] => int note;
+  scale[Math.random2(0,scale.size()-1)] => int note;
   33 + Math.random2(0,4)*12 + note => Std.mtof => hole.freq;
   <<< "note: ", Std.ftom( hole.freq() ) >>>;
 

--- a/src/examples/stk/blowhole2.ck
+++ b/src/examples/stk/blowhole2.ck
@@ -36,7 +36,7 @@ while( true )
   }
 
   // set freq
-  scale[Math.random2(0,scale.cap()-1)] => int note;
+  scale[Math.random2(0,scale.size()-1)] => int note;
   33 + Math.random2(0,4)*12 + note => Std.mtof => hole.freq;
   <<< "note: ", Std.ftom( hole.freq() ) >>>;
 

--- a/src/examples/stk/bowed.ck
+++ b/src/examples/stk/bowed.ck
@@ -23,7 +23,7 @@ while( true )
     <<< "volume:", bow.volume() >>>;
 
     // set freq
-    scale[Math.random2(0,scale.cap()-1)] + 57 => Std.mtof => bow.freq;
+    scale[Math.random2(0,scale.size()-1)] + 57 => Std.mtof => bow.freq;
     // go
     .8 => bow.noteOn;
 

--- a/src/examples/stk/bowed2.ck
+++ b/src/examples/stk/bowed2.ck
@@ -32,7 +32,7 @@ while( true )
     bow.controlChange( 128, volume );
 
     // set freq
-    scale[Math.random2(0,scale.cap()-1)] + 57 => Std.mtof => bow.freq;
+    scale[Math.random2(0,scale.size()-1)] + 57 => Std.mtof => bow.freq;
     // go
     .8 => bow.noteOn;
 

--- a/src/examples/stk/brass.ck
+++ b/src/examples/stk/brass.ck
@@ -24,7 +24,7 @@ while( true )
     <<< "vibrato gain:", brass.vibratoGain() >>>;
     <<< "volume:", brass.volume() >>>;
 
-    for( int i; i < notes.cap(); i++ )
+    for( int i; i < notes.size(); i++ )
     {
         play( 12 + notes[i], Math.random2f( .6, .9 ) );
         300::ms => now;

--- a/src/examples/stk/brass2.ck
+++ b/src/examples/stk/brass2.ck
@@ -33,7 +33,7 @@ while( true )
     // volume
     brass.controlChange( 128, volume );
 
-    for( int i; i < notes.cap(); i++ )
+    for( int i; i < notes.size(); i++ )
     {
         play( 12 + notes[i], Math.random2f( .6, .9 ) );
         300::ms => now;

--- a/src/examples/stk/clarinet.ck
+++ b/src/examples/stk/clarinet.ck
@@ -30,7 +30,7 @@ while( true )
     <<< "vibrato gain:", clair.vibratoGain() >>>;
     <<< "breath pressure:", clair.pressure() >>>;
 
-    for( int i; i < notes.cap(); i++ )
+    for( int i; i < notes.size(); i++ )
     {
         play( 12 + notes[i], Math.random2f( .6, .9 ) );
         300::ms => now;

--- a/src/examples/stk/clarinet2.ck
+++ b/src/examples/stk/clarinet2.ck
@@ -39,7 +39,7 @@ while( true )
     // breath pressure
     clair.controlChange( 128, pressure );
 
-    for( int i; i < notes.cap(); i++ )
+    for( int i; i < notes.size(); i++ )
     {
         play( 12 + notes[i], Math.random2f( .6, .9 ) );
         300::ms => now;

--- a/src/examples/stk/flute.ck
+++ b/src/examples/stk/flute.ck
@@ -37,7 +37,7 @@ while( true )
     // factor
     Math.random2f( .75, 2 ) => float factor;
 
-    for( int i; i < notes.cap(); i++ )
+    for( int i; i < notes.size(); i++ )
     {
         play( 12 + notes[i], Math.random2f( .6, .9 ) );
         300::ms * factor => now;

--- a/src/examples/stk/mand-o-matic-simple.ck
+++ b/src/examples/stk/mand-o-matic-simple.ck
@@ -20,7 +20,7 @@ while( true )
     // position
     Math.random2f( 0.2, 0.8 ) => mand.pluckPos;
     // frequency...
-    scale[Math.random2(0,scale.cap()-1)] => int freq;
+    scale[Math.random2(0,scale.size()-1)] => int freq;
     45 + Math.random2(0,3)*12 + freq => Std.mtof => mand.freq;
     // pluck it!
     Math.random2f( 0.2, 0.9 ) => mand.pluck;

--- a/src/examples/stk/mand-o-matic.ck
+++ b/src/examples/stk/mand-o-matic.ck
@@ -59,7 +59,7 @@ while( true )
     // position
     Math.random2f( 0.2, 0.8 ) => mand.pluckPos;
     // frequency...
-    scale[Math.random2(0,scale.cap()-1)] => int freq;
+    scale[Math.random2(0,scale.size()-1)] => int freq;
     220.0 * Math.pow( 1.05946, (Math.random2(0,2)*12) + freq ) => mand.freq;
     // pluck it!
     Math.random2f( 0.2, 0.9 ) => mand.pluck;

--- a/src/examples/stk/mandolin.ck
+++ b/src/examples/stk/mandolin.ck
@@ -27,7 +27,7 @@ while( true )
     // factor
     Math.random2f( 1, 4 ) => float factor;
 
-    for( int i; i < notes.cap(); i++ )
+    for( int i; i < notes.size(); i++ )
     {
         play( Math.random2(0,2)*12 + notes[i], Math.random2f( .6, .9 ) );
         100::ms * factor => now;

--- a/src/examples/stk/modalbar.ck
+++ b/src/examples/stk/modalbar.ck
@@ -31,7 +31,7 @@ while( true )
     <<< "master gain:", bar.masterGain() >>>;
 
     // set freq
-	scale[Math.random2(0,scale.cap()-1)] => int winner;
+	scale[Math.random2(0,scale.size()-1)] => int winner;
     57 + Math.random2(0,2)*12 + winner => Std.mtof => bar.freq;
     // go
     .8 => bar.noteOn;

--- a/src/examples/stk/modalbar2.ck
+++ b/src/examples/stk/modalbar2.ck
@@ -38,7 +38,7 @@ while( true )
     <<< "master gain:", masterGain, "/ 128.0" >>>;
 
     // set freq
-	scale[Math.random2(0,scale.cap()-1)] => int winner;
+	scale[Math.random2(0,scale.size()-1)] => int winner;
     57 + Math.random2(0,2)*12 + winner => Std.mtof => bar.freq;
     // go
     .8 => bar.noteOn;

--- a/src/examples/stk/mode-o-matic.ck
+++ b/src/examples/stk/mode-o-matic.ck
@@ -72,7 +72,7 @@ while( true )
     // position
     Math.random2f( 0.2, 0.8 ) => modey.strikePosition;
     // frequency...
-    scale[Math.random2(0,scale.cap()-1)] => int freq;
+    scale[Math.random2(0,scale.size()-1)] => int freq;
     Std.mtof( 45 + Math.random2(0,4)*12 + freq ) => modey.freq;
 
     // pluck it!

--- a/src/examples/stk/mode-o-test.ck
+++ b/src/examples/stk/mode-o-test.ck
@@ -24,7 +24,7 @@ while( true )
     which => modey.preset;
 
     // frequency...
-    scale[Math.random2(0,scale.cap()-1)] => int freq;
+    scale[Math.random2(0,scale.size()-1)] => int freq;
     Math.mtof( 33 + (Math.random2(0,3)*12) + freq ) => modey.freq;
 
     // velocity

--- a/src/examples/stk/moog.ck
+++ b/src/examples/stk/moog.ck
@@ -25,7 +25,7 @@ while( true )
     <<< "volume:", moog.volume() >>>;
 
     // set freq
-    scale[Math.random2(0,scale.cap()-1)] => int winner;
+    scale[Math.random2(0,scale.size()-1)] => int winner;
     57 + Math.random2(0,2)*12 + winner => Std.mtof => moog.freq;
 
     // go

--- a/src/examples/stk/moog2.ck
+++ b/src/examples/stk/moog2.ck
@@ -32,7 +32,7 @@ while( true )
     <<< "vibrato gain:", moog.vibratoGain() >>>;
 
     // set freq
-    scale[Math.random2(0,scale.cap()-1)] => int winner;
+    scale[Math.random2(0,scale.size()-1)] => int winner;
     57 + Math.random2(0,2)*12 + winner => Std.mtof => moog.freq;
     // go
     .8 => moog.noteOn;

--- a/src/examples/stk/rhodey.ck
+++ b/src/examples/stk/rhodey.ck
@@ -54,7 +54,7 @@ spork ~ vecho_Shred();
 while( true )
 { 
     // pentatonic
-    scale[Math.random2(0,scale.cap()-1)] => int freq;
+    scale[Math.random2(0,scale.size()-1)] => int freq;
 
     Std.mtof( ( 33 + Math.random2(0,1) * 12 + freq ) ) => voc.freq;
     Math.random2f( 0.6, 0.8 ) => voc.noteOn;

--- a/src/examples/stk/saxofony.ck
+++ b/src/examples/stk/saxofony.ck
@@ -33,7 +33,7 @@ while( true )
     // factor
     Math.random2f( .75, 2 ) => float factor;
 
-    for( int i; i < notes.cap(); i++ )
+    for( int i; i < notes.size(); i++ )
     {
         play( 12 + notes[i], Math.random2f( .6, .9 ) );
         300::ms * factor => now;

--- a/src/examples/stk/stif-o-karp.ck
+++ b/src/examples/stk/stif-o-karp.ck
@@ -59,7 +59,7 @@ while( true )
     // position
     Math.random2f( 0.2, 0.8 ) => karp.pickupPosition;
     // frequency...
-    scale[Math.random2(0,scale.cap()-1)] => int freq;
+    scale[Math.random2(0,scale.size()-1)] => int freq;
     220.0 * Math.pow( 1.05946, (Math.random2(0,2)*12)
                       +freq ) => karp.freq;
     // pluck it!

--- a/src/examples/stk/stifkarp.ck
+++ b/src/examples/stk/stifkarp.ck
@@ -23,7 +23,7 @@ while( true )
     // factor
     Math.random2f( 1, 4 ) => float factor;
 
-    for( int i; i < notes.cap(); i++ )
+    for( int i; i < notes.size(); i++ )
     {
         play( Math.random2(0,2)*12 + notes[i], Math.random2f( .6, .9 ) );
         100::ms * factor => now;

--- a/src/examples/stk/voic-o-form.ck
+++ b/src/examples/stk/voic-o-form.ck
@@ -84,6 +84,6 @@ while( true )
     }
 
     // pentatonic
-    scale[Math.random2(0,scale.cap()-1)] => int freq;
+    scale[Math.random2(0,scale.size()-1)] => int freq;
     Std.mtof( ( 45 + Math.random2(0,2) * 12 + freq ) ) => voc.freq;
 }

--- a/src/examples/stk/wurley.ck
+++ b/src/examples/stk/wurley.ck
@@ -16,7 +16,7 @@ Wurley voc=> JCRev r => dac;
 while( true )
 {
     // scale
-    scale[Math.random2(0,scale.cap()-1)] => int freq;
+    scale[Math.random2(0,scale.size()-1)] => int freq;
     Std.mtof( ( 45 + Math.random2(0,1) * 12 + freq ) ) => voc.freq;
     Math.random2f( 0.6, 0.8 ) => voc.noteOn;
 

--- a/src/examples/stk/wurley2.ck
+++ b/src/examples/stk/wurley2.ck
@@ -54,7 +54,7 @@ spork ~ vecho_Shred();
 while( true )
 {
     // scale
-    scale[Math.random2(0,scale.cap()-1)] => int freq;
+    scale[Math.random2(0,scale.size()-1)] => int freq;
     Std.mtof( ( 45 + Math.random2(0,1) * 12 + freq ) ) => voc.freq;
     Math.random2f( 0.6, 0.8 ) => voc.noteOn;
 

--- a/src/examples/stk/wurley3.ck
+++ b/src/examples/stk/wurley3.ck
@@ -11,7 +11,7 @@ int which;
 Gain g => dac;
 .4 => g.gain;
 // connect the wurlies
-for( int i; i < wurlies.cap(); i++ )
+for( int i; i < wurlies.size(); i++ )
     wurlies[i] => g;
 
 // our notes
@@ -20,7 +20,7 @@ for( int i; i < wurlies.cap(); i++ )
 // infinite time-loop
 while( true )
 {
-    for( int i; i < notes.cap(); i++ )
+    for( int i; i < notes.size(); i++ )
     {
         play( notes[i], Math.random2f( .3, .9 ) );
         300::ms => now;
@@ -32,7 +32,7 @@ fun void play( float note, float velocity )
 {
     // first figure which to play
     // round robin may work
-    ( which + 1 ) % wurlies.cap() => which;
+    ( which + 1 ) % wurlies.size() => which;
 
     // start the note
     Std.mtof( note ) => wurlies[which].freq;

--- a/src/examples/type/type_analysis.ck
+++ b/src/examples/type/type_analysis.ck
@@ -64,13 +64,13 @@
 
 // array
 complex arr[10];
-<<< arr.cap() >>>;
+<<< arr.size() >>>;
 <<< arr[0] >>>;
 #(10, 11) => arr[1];
 <<< arr[1] >>>;
 
 polar brr[10];
-<<< brr.cap() >>>;
+<<< brr.size() >>>;
 <<< brr[0] >>>;
 %(5,pi) => brr[1];
 <<< brr[1] >>>;
@@ -85,7 +85,7 @@ polar brr[10];
 
 // arrays
 [ #(1,2), #(3,4), #(5,6) ] @=> complex cs[];
-polar ps[cs.cap()];
+polar ps[cs.size()];
 // convert
 Math.rtop( cs, ps );
 <<< ps[0], ps[1], ps[2] >>>;


### PR DESCRIPTION
Fixes #68 

The first commit replaces references to the `cap` method in the manual with `size`, as per the preference in #68, and adds in a line about "this method sometimes being called 'length'" in other language in an attempt to help people who ctrl+f for what they're trying to find quickly.

The second commit may be somewhat controversial, it replaces calls to `cap` in the examples with calls to `size`, to try and encourage first time ChucK programmers who are going through the examples to use `size`. Happy to remove/edit that commit from this PR.

