### PR TITLE
Name sporked threads with function name and line number

### DIFF
--- a/src/chuck_emit.cpp
+++ b/src/chuck_emit.cpp
@@ -34,6 +34,7 @@
 #include "chuck_vm.h"
 #include "chuck_errmsg.h"
 #include "chuck_instr.h"
+#include <sstream>
 
 using namespace std;
 
@@ -4582,8 +4583,12 @@ t_CKBOOL emit_engine_emit_spork( Chuck_Emitter * emit, a_Exp_Func_Call exp )
     emit->code = new Chuck_Code;
     // handle need this
     emit->code->need_this = exp->ck_func->is_member;
-    // name it
-    emit->code->name = "spork~exp";
+    // name it: e.g. spork~foo [line 5]
+    std::ostringstream name;
+    name << "spork~"
+         << exp->ck_func->name.substr( 0, exp->ck_func->name.find( "@" ))
+         << " [line " << exp->linepos << "]";
+    emit->code->name = name.str();
     // keep track of full path (added 1.3.0.0)
     emit->code->filename = emit->context->full_path;
     // push op


### PR DESCRIPTION
Building off of the comments on #77, and following the convention established in the `spork~{code}` branch in a6e17ea5bec7c87e2fdbcd907875bce91489fb3b,* this pull request would change the name of `spork~function()` shreds from `spork~exp` to `spork~func_name [line #]`. 


\* that is to say, that sporked code blocks are named `spork~{code} [line #]`.