### PR TITLE
Don't let ChucK hang if an error occurs before any shreds execute

### DIFF
--- a/src/chuck_vm.cpp
+++ b/src/chuck_vm.cpp
@@ -566,7 +566,8 @@ t_CKBOOL Chuck_VM::compute()
             release_dump();
     }
     
-    return TRUE;
+    // continue executing if have shreds left or if don't-halt
+    return ( m_num_shreds || !m_halt );
 }
 
 


### PR DESCRIPTION
Line 535: `if( !m_num_shreds && m_halt ) return FALSE;`

Line 535 (viewable in context if you expand the source above this commit a couple times) is responsible for the return value `FALSE` that propagates up and ends the execution loop of the chuck binary. It returns `FALSE` if  the VM has no more shreds and if `m_halt` is `TRUE`. But, this check is only performed when a shred finishes running.

In cases where an error occurs before a shred can begin to execute, such as a syntax error, this line is never touched, the `Chuck_VM::compute()` function always returns `TRUE` and ChucK executes forever (must use CTRL-C to escape).

This PR replaces the `return TRUE` at the end of `Chuck_VM::compute()` with an additional check on whether there are any shreds left or if `m_halt` is `FALSE`. Now, even if no shreds ever execute, the chuck binary can still exit if there are no shreds left to execute and the halt flag is on. The binary no longer hangs on syntax / compile-time errors.

What I don't know is whether there's ever a situation where `m_num_shreds` is 0 at the end of `Chuck_VM::compute()`, but there would be another shred added by the next time `Chuck_VM::compute()` is called. In such a situation, this PR would return `FALSE` at the end of the first call to `compute()` and the second call would never have a chance to execute. For this situation to arise, `compute()` would have to be called at least once with `m_halt == TRUE` before the first shred is ever added. (If a shred had been added and finished executing, then line 535 as it exists already would cause the chuck binary to exit; so such a situation can only occur with the first shred of execution.) However, all of the tests I've run so far have passed.

Because this touches such a core piece of the repository, I'd like to get a few pairs of eyes on it.

This change is necessary to add automated tests that check for syntax / other compile-time errors, since if the chuck binary hangs forever, then the testing framework will hang forever. Plus, it will be nice to do a lot less CTRL-C'ing.