### PR TITLE
Rephrase assertion failure as error message

### DIFF
--- a/src/chuck_type.cpp
+++ b/src/chuck_type.cpp
@@ -3712,9 +3712,14 @@ t_CKTYPE type_engine_check_exp_array( Chuck_Env * env, a_Exp_Array array )
         e = e->next;
     }
 
-    // sanity
-    assert( array->indices->depth == depth );
-
+    //TODO: catch commas inside array subscripts earlier on, perhaps in .y
+    if( array->indices->depth != depth )
+    {
+      EM_error2( array->linepos,
+          "[..., ...] is invalid subscript syntax." );
+      return NULL;
+    }
+  
     t_CKTYPE t = NULL;
     // make sure depth <= max
     if( depth == t_base->array_depth )


### PR DESCRIPTION
As requested in [issue #43](https://github.com/ccrma/chuck/issues/43#issuecomment-282459346). This addresses but one issue of potentially many brought upon by not disallowing commas in array subscripts.