### PR TITLE
Reset lisa loop record point to loop start rather than the start of the lisa buffer when the loop end is reached.

### DIFF
--- a/src/core/ugen_xxx.cpp
+++ b/src/core/ugen_xxx.cpp
@@ -3785,7 +3785,7 @@ struct LiSaMulti_data
         
         if(record) {
             if(looprec) {
-                if(rindex >= loop_end_rec)  rindex = 0;
+                if(rindex >= loop_end_rec)  rindex = loop_start[0];
                 tempsample = coeff * mdata[rindex] + insample;
                 //mdata[rindex] = coeff * mdata[rindex] + insample;
                 //rindex++;


### PR DESCRIPTION
This was made to fix an issues I found when working with lisa loops. Looped overdubbing would break as the record position got reset to the beginning of the buffer rather than the loop start when the end of the loop was reached. This better matches the behavior of the play positions and fixes what I believe is currently a bug.