### PR TITLE
Fix for windows shutdown otf listener crash.

### DIFF
--- a/src/core/chuck.cpp
+++ b/src/core/chuck.cpp
@@ -671,18 +671,22 @@ bool ChucK::shutdown()
     stk_detach( m_carrier );
     
     // cancel otf thread
+    if(m_carrier->otf_thread)
+    {
 #if !defined(__PLATFORM_WIN32__) || defined(__WINDOWS_PTHREAD__)
-    if( m_carrier->otf_thread ) pthread_cancel( m_carrier->otf_thread );
+        pthread_cancel( m_carrier->otf_thread );
 #else
-    if( m_carrier->otf_thread ) CloseHandle( m_carrier->otf_thread );
+        CloseHandle( m_carrier->otf_thread ); // doesn't cancel thread
 #endif
+        m_carrier->otf_thread = 0; // signals thread shutdown
+    }
+
     // close otf socket
     if( m_carrier->otf_socket ) ck_close( m_carrier->otf_socket );
     
     // reset
     m_carrier->otf_socket = NULL;
     m_carrier->otf_port = 0;
-    m_carrier->otf_thread = 0;
     
     // TODO: a different way to unlock?
     // unlock all objects to delete chout, cherr

--- a/src/core/chuck_otf.cpp
+++ b/src/core/chuck_otf.cpp
@@ -642,12 +642,17 @@ void * otf_cb( void * p )
     {
         // REFACTOR-2017: change g_sock to per-VM socket
         client = ck_accept( carrier->otf_socket );
+
+        // check for thread shutdown, potentially occured during ck_accept
+        if(!carrier->otf_thread) 
+            break;
+
         if( !client )
         {
             if( carrier->vm )
                 EM_log( CK_LOG_INFO, "[chuck]: socket error during accept()...\n" );
             usleep( 40000 );
-            ck_close( client );
+            // ck_close( client );  don't close NULL client
             continue;
         }
         msg.clear();


### PR DESCRIPTION
CloseHandle on thread apparently doesn't actually terminate the thread.
Shutdown in the main thread causes the otf state to be freed out from under
the otf listener and can result in crashes. Here we signal otf shutdown
to the otf thread via the thread id/handle. It's possible that a more
principled approach is required (where we wait for proper thread shutdown).
Windows docs suggest we not explicitly kill the thread since there may be
dangling resources.  Testing and casual code inspection suggests that this
solution may be adequate.