### PR TITLE
Fix assertion to check that all three array sizes are equal.

### DIFF
--- a/src/core/uana_extract.cpp
+++ b/src/core/uana_extract.cpp
@@ -1378,7 +1378,7 @@ CK_DLL_SFUN( XCorr_compute )
 void xcorr_fft( SAMPLE * f, t_CKINT fsize, SAMPLE * g, t_CKINT gsize, SAMPLE * buffy, t_CKINT size )
 {
     // sanity check
-    assert( fsize == gsize == size );
+    assert( fsize == gsize && gsize == size );
 
     // take fft
     rfft( f, size/2, FFT_FORWARD );


### PR DESCRIPTION
This sample program demonstrates the issue:
```
SinOsc s => FFT fft =^ AutoCorr cor => blackhole;
1024 => fft.size;
440 => s.freq;
while(true) {
  cor.upchuck();
  20::ms => now;
}
...
chuck: uana_extract.cpp:1381: void xcorr_fft(float*, long int, float*, long int, float*, long int): Assertion `fsize == gsize == size' failed.
```