### PR TITLE
The input is already in the frequency domain, so don't take the FFT.

### DIFF
--- a/src/core/uana_extract.cpp
+++ b/src/core/uana_extract.cpp
@@ -1380,10 +1380,6 @@ void xcorr_fft( SAMPLE * f, t_CKINT fsize, SAMPLE * g, t_CKINT gsize, SAMPLE * b
     // sanity check
     assert( fsize == gsize && gsize == size );
 
-    // take fft
-    rfft( f, size/2, FFT_FORWARD );
-    rfft( g, size/2, FFT_FORWARD );
-
     // complex
     t_CKCOMPLEX_SAMPLE * F = (t_CKCOMPLEX_SAMPLE *)f;
     t_CKCOMPLEX_SAMPLE * G = (t_CKCOMPLEX_SAMPLE *)g;


### PR DESCRIPTION
As seen in [XCorr_tock](https://github.com/ccrma/chuck/blob/main/src/core/uana_extract.cpp#L1302) and [AutoCorr_tock](https://github.com/ccrma/chuck/blob/main/src/core/uana_extract.cpp#L1210) their input has to be from UAnae, so this produces an array of all zeroes:
```ChucK
SinOsc s => AutoCorr c => blackhole;
440 => s.freq;
300::ms => now;
c.upchuck();
// c.fvals() is all zeroes
200::ms => now;
```
The natural implication is that we must use the FFT UAna in the analysis graph. However, doing this results in puzzling output.
```ChucK
SinOsc s => FFT fft =^ AutoCorr c => blackhole;
440 => s.freq;
300::ms => now;
c.upchuck();
// c.fvals() has the double FFT autocorrelation
200::ms => now;
```
I expect the output to have some periodicity, but it's nothing of the sort. ![autocorr-with-bug](https://user-images.githubusercontent.com/489307/88364837-0c374480-cd39-11ea-9ccc-ddd42af1dbbd.png)

I noticed that xcorr_fft is taking the FFT of the already-transformed input. After this commit, this is the autocorrelation output using Mario's [gnuplot wrapper](https://github.com/mariobuoninfante/ChucK_various).
```ChucK
// run as chuck --caution-to-the-wind Plot.ck test.ck
SinOsc s => FFT fft =^ AutoCorr c => dac;
413 => s.freq;
s => WvOut w => blackhole;
"413.wav" => w.wavFilename; // save the audio to use for external verification
2048 => fft.size;
fft.size()::samp => now;
fft.upchuck();
c.upchuck();
Plot plot;
"autocorrelation of " + s.freq()$int + " hz sine wave, " + fft.size() + " samples" => plot.title;
plot.plot(c.fvals());
w.closeFile();
100::ms => now;
```
![autcorr-fixed](https://user-images.githubusercontent.com/489307/88364817-00e41900-cd39-11ea-9ff6-70d95c5635a5.png)

I tried to confirm the output using numpy autocorrelation. The patterns are clearly the same but the number of peaks is different. I don't fully understand why.
```python
import numpy
from numpy.fft import fft, ifft
import matplotlib.pyplot as plt
import librosa

x, sr = librosa.load('413.wav')

# x = fft(x) # uncomment to replicate the bug
r = ifft(fft(x) * fft(x).conj()).real
# or equivalently:
# r = numpy.correlate(x, numpy.hstack((x[1:], x)), mode='valid')

r = numpy.interp(r, (r.min(), r.max()), (-.5, .5))

plt.figure(figsize=(12, 8))
plt.ylim(-.5,.5)
plt.plot(r)
plt.xlabel('numpy circular autocorrelation of 413.wav')
plt.xlim(0, len(x))
plt.savefig('numpy.png')
```
![numpy-autocorrelation](https://user-images.githubusercontent.com/489307/88364781-e5790e00-cd38-11ea-928b-e3d37c0b58bc.png)
![numpy-with-extra-fft](https://user-images.githubusercontent.com/489307/88364788-edd14900-cd38-11ea-9f42-184839e4a23f.png)
