### PR TITLE
Fix .gitignore for src/core reorganisation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,13 @@
 *.d
 *.o
 
-src/chuck
-src/chuck.output
-src/chuck.tab.c
-src/chuck.tab.h
-src/chuck.yy.c
-src/Release
-src/Debug
+/src/chuck
+/src/core/chuck.output
+/src/core/chuck.tab.c
+/src/core/chuck.tab.h
+/src/core/chuck.yy.c
+/src/Release
+/src/Debug
 
 .DS_Store
 project.xcworkspace


### PR DESCRIPTION
Also changed to repository-root-pinned paths to improve specificity -
otherwise a file named `chuck` in some other possible `src` subdirectory
would be possibly-unexpededly ignored.