### PR TITLE
makefile.osx: fix build without Xcode

### DIFF
--- a/src/core/makefile.x/makefile.osx
+++ b/src/core/makefile.x/makefile.osx
@@ -2,7 +2,7 @@
 # FORCE_M32=-m32
 
 ifneq ($(shell sw_vers -productVersion | egrep '10\.(6|7|8|9|10|11|12|13|14|15)(\.[0-9]+)?'),)
-SDK=$(shell xcodebuild -sdk macosx -version | grep '^Path:' | sed 's/Path: \(.*\)/\1/')
+SDK=$(shell xcrun --show-sdk-path)
 ISYSROOT=-isysroot $(SDK)
 LINK_EXTRAS=-F/System/Library/PrivateFrameworks \
     -weak_framework MultitouchSupport


### PR DESCRIPTION
xcodebuild is only available with Xcode installed (unnecessary)
xcrun will retrieve the SDK path