### PR TITLE
Fix Linux build in GitHub Actions

### DIFF
--- a/.github/workflows/linux-build-unit-tests.yml
+++ b/.github/workflows/linux-build-unit-tests.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Dependencies - Linux
-      run: sudo apt-get install -y libsndfile1-dev && sudo apt-get install -y libpulse-dev && sudo apt-get install -y libasound2-dev
+      run: sudo apt install --fix-missing -y libsndfile1-dev libpulse-dev libasound2-dev
 
     - name: Compile - Linux
       run: cd src/ && make linux-pulse

--- a/.github/workflows/linux-build-unit-tests.yml
+++ b/.github/workflows/linux-build-unit-tests.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Dependencies - Linux
-      run: sudo apt install --fix-missing -y libsndfile1-dev libpulse-dev libasound2-dev
+      run: sudo apt update && sudo apt install --fix-missing -y libsndfile1-dev libpulse-dev libasound2-dev
 
     - name: Compile - Linux
       run: cd src/ && make linux-pulse


### PR DESCRIPTION
Linux dependencies are failing to install because the azure debian repository metadata seem to point to binaries that aren't in the repository. The output of the command suggests to use the `--fix-missing` flag, so I thought I'd open a PR to see if it helps. I also ran the command to update the local apt repository before installing, that seemed to be tripping it up too.