### PR TITLE
Add reading audio and code from JAR acrhives on Android

### DIFF
--- a/src/core/chuck.cpp
+++ b/src/core/chuck.cpp
@@ -526,6 +526,18 @@ bool ChucK::initCompiler()
             // log it
             EM_log( CK_LOG_INFO, "current working directory:" );
         }
+#ifdef __ANDROID__
+        else if( workingDir.rfind("jar:", 0) == 0 )
+        {
+            // if workingDir is a JAR URL, make sure it ends on /
+            if( *workingDir.rbegin() != '/' )
+            {
+                workingDir = workingDir + "/";
+            }
+            // log it
+            EM_log( CK_LOG_INFO, "setting current working directory:" );
+        }
+#endif
         else
         {
             // update

--- a/src/core/chuck.cpp
+++ b/src/core/chuck.cpp
@@ -820,6 +820,23 @@ bool ChucK::compileFile( const std::string & path, const std::string & argsToget
     
     // append
     std::string theThing = path + ":" + argsTogether;
+#ifdef __ANDROID__
+    if( theThing.rfind("jar:", 0) == 0 )
+    {
+        const size_t jarPrefixLen = strlen("jar:");
+        const size_t secondColon = path.find(':', jarPrefixLen);
+        if( secondColon == std::string::npos )
+        {
+            theThing = std::string("jar\\:") + theThing.substr(jarPrefixLen);
+        }
+        else
+        {
+            theThing = std::string("jar\\:") + theThing.substr(jarPrefixLen,
+                secondColon - jarPrefixLen) + std::string("\\:") +
+                theThing.substr(secondColon + 1);
+        }
+    }
+#endif // __ANDROID__
     
     // parse out command line arguments
     if( !extract_args( theThing, filename, args ) )

--- a/src/core/chuck_parse.cpp
+++ b/src/core/chuck_parse.cpp
@@ -35,6 +35,10 @@
 #include <string.h>
 using namespace std;
 
+#ifdef __ANDROID__
+#include "util_platforms.h"
+#endif
+
 
 // max path len
 static const t_CKUINT MAX_FILENAME_LEN = 2048;
@@ -55,6 +59,19 @@ extern "C" {
 //-----------------------------------------------------------------------------
 FILE * open_cat_ck( c_str fname )
 {
+#ifdef __ANDROID__
+    if( strncmp(fname, "jar:", strlen("jar:")) == 0 )
+    {
+        int fd = 0;
+        if( !ChuckAndroid::copyJARURLFileToTemporary(fname, &fd) )
+        {
+            EM_error2( 0, "unable to download from JAR URL: %s", fname );
+            return NULL;
+        }
+        return fdopen(fd, "rb");
+    }
+#endif // __ANDROID__
+
     FILE * fd = NULL;
     if( !(fd = fopen( fname, "rb" )) )
         if( !strstr( fname, ".ck" ) && !strstr( fname, ".CK" ) )
@@ -102,8 +119,6 @@ FILE *win32_tmpfile()
 // desc: replacement for broken tmpfile() on Android
 //-----------------------------------------------------------------------------
 #ifdef __ANDROID__
-
-#include "util_platforms.h"
 
 FILE * android_tmpfile()
 {

--- a/src/core/util_platforms.cpp
+++ b/src/core/util_platforms.cpp
@@ -421,10 +421,14 @@ bool ChuckAndroid::copyJARURLFileToTemporary(const char * jar_url, int * fd)
         // s = input_stream.read(buffer)
         jclass input_stream_class = jni.FindClass("java/io/InputStream");
         jint s = 0;
-        do
+        while( true )
         {
             s = jni.CallIntMethod(input_stream, input_stream_class, "read",
                 "([B)I", java_buffer);
+            if( s < 0 )
+            {
+                break;
+            }
             jbyte * native_buffer = jni.GetByteArrayElements(java_buffer);
             size_t written = 0;
             while( written < s )
@@ -439,7 +443,7 @@ bool ChuckAndroid::copyJARURLFileToTemporary(const char * jar_url, int * fd)
                 written += written_now;
             }
             jni.ReleaseByteArrayElements(java_buffer, native_buffer);
-        } while( s > 0 );
+        }
 
         // jar_file.close()
         jni.CallVoidMethod(jar_file, jar_file_class, "close", "()V");

--- a/src/core/util_platforms.cpp
+++ b/src/core/util_platforms.cpp
@@ -39,9 +39,9 @@
 #ifdef __ANDROID__
 //-----------------------------------------------------------------------------
 #include <jni.h>
-#include <cassert>
-#include <memory>
-#include <functional>
+#include <fcntl.h>
+#include <unistd.h>
+#include <string>
 
 static JavaVM * jvm_instance = NULL;
 
@@ -57,90 +57,405 @@ JavaVM * ChuckAndroid::getJVM()
     return jvm_instance;
 }
 
-FILE * ChuckAndroid::getTemporaryFile()
+//-----------------------------------------------------------------------------
+// name: class JNIEnvWrapper
+// desc: Wrapper around JNIEnv. Serves three purposes:
+//       - releases JNIEnv and Java objects in RAII fashion
+//       - removes the need to get method IDs
+//       - throws JNIEnvWrapperException exception on Java exceptions
+//-----------------------------------------------------------------------------
+class JNIEnvWrapper
+{
+public:
+    JNIEnvWrapper(JavaVM * jvm);
+    ~JNIEnvWrapper();
+
+    bool IsValid() const;
+
+    jclass FindClass(const char * class_signature);
+    jobject ConstructNewObject(jclass constructed_class,
+        const char * constructor_signature, jobject param_1);
+    jobject CallObjectMethod(jobject callee, jclass callee_class,
+        const char * method_name, const char * method_signature);
+    jobject CallObjectMethod(jobject callee, jclass callee_class,
+        const char * method_name, const char * method_signature,
+        jobject param_1);
+    jobject CallStaticObjectMethod(jclass callee_class,
+        const char * method_name, const char * method_signature);
+    jobject CallStaticObjectMethod(jclass callee_class,
+        const char * method_name, const char * method_signature,
+        jobject param_1);
+    jobject CallStaticObjectMethod(jclass callee_class,
+        const char * method_name, const char * method_signature,
+        jobject param_1, jobject param_2, jobject param_3);
+    jint CallIntMethod(jobject callee, jclass callee_class,
+        const char * method_name, const char * method_signature,
+        jobject param_1);
+    void CallVoidMethod(jobject callee, jclass callee_class,
+        const char * method_name, const char * method_signature);
+
+    jstring NewStringUTF(const char * utf8_string);
+    const char * GetStringUTFChars(jstring string);
+    void ReleaseStringUTFChars(jstring string, const char * utf8_chars);
+    jbyteArray NewByteArray(size_t size);
+    jbyte * GetByteArrayElements(jbyteArray java_array);
+    void ReleaseByteArrayElements(jbyteArray java_array, jbyte * native_array);
+
+private:
+    void ThrowOnJavaException();
+    JavaVM * m_jvm = NULL;
+    JNIEnv * m_env = NULL;
+    bool m_needs_detaching = false;
+};
+
+class JNIEnvWrapperException {};
+
+JNIEnvWrapper::JNIEnvWrapper(JavaVM * jvm)
+    : m_jvm(jvm)
+{
+    int reason = jvm->GetEnv((void **)&m_env, JNI_VERSION_1_6);
+    if( reason != JNI_OK && reason != JNI_EDETACHED )
+    {
+        m_env = NULL;
+        return;
+    }
+    if( reason == JNI_EDETACHED )
+    {
+        if( jvm->AttachCurrentThread(&m_env, NULL) != 0 )
+        {
+            m_env = NULL;
+            return;
+        }
+        m_needs_detaching = true;
+    }
+    if( m_env->PushLocalFrame(32) != 0 )
+    {
+        if( m_needs_detaching )
+        {
+            m_jvm->DetachCurrentThread();
+        }
+        m_env = NULL;
+    }
+}
+
+JNIEnvWrapper::~JNIEnvWrapper()
+{
+    if( m_env == NULL )
+    {
+        return;
+    }
+    m_env->PopLocalFrame(NULL);
+    if( m_needs_detaching )
+    {
+        m_jvm->DetachCurrentThread();
+    }
+}
+
+bool JNIEnvWrapper::IsValid() const
+{
+    return m_env != NULL;
+}
+
+void JNIEnvWrapper::ThrowOnJavaException()
+{
+    if( m_env->ExceptionCheck() )
+    {
+        m_env->ExceptionDescribe();
+        m_env->ExceptionClear();
+        throw JNIEnvWrapperException();
+    }
+}
+
+jclass JNIEnvWrapper::FindClass(const char * class_signature)
+{
+    jclass ret = m_env->FindClass(class_signature);
+    ThrowOnJavaException();
+    return ret;
+}
+
+jobject JNIEnvWrapper::ConstructNewObject(jclass constructed_class,
+    const char * constructor_signature, jobject param_1)
+{
+    jmethodID method_id = m_env->GetMethodID(constructed_class,
+        "<init>", constructor_signature);
+    ThrowOnJavaException();
+    jobject ret = m_env->NewObject(constructed_class, method_id,
+        param_1);
+    ThrowOnJavaException();
+    return ret;
+}
+
+jobject JNIEnvWrapper::CallObjectMethod(jobject callee, jclass callee_class,
+    const char * method_name, const char * method_signature)
+{
+    jmethodID method_id = m_env->GetMethodID(callee_class,
+        method_name, method_signature);
+    ThrowOnJavaException();
+    jobject ret = m_env->CallObjectMethod(callee, method_id);
+    ThrowOnJavaException();
+    return ret;
+}
+
+jobject JNIEnvWrapper::CallObjectMethod(jobject callee, jclass callee_class,
+    const char * method_name, const char * method_signature,
+    jobject param_1)
+{
+    jmethodID method_id = m_env->GetMethodID(callee_class,
+        method_name, method_signature);
+    ThrowOnJavaException();
+    jobject ret = m_env->CallObjectMethod(callee, method_id, param_1);
+    ThrowOnJavaException();
+    return ret;
+}
+
+jobject JNIEnvWrapper::CallStaticObjectMethod(jclass callee_class,
+    const char * method_name, const char * method_signature)
+{
+    jmethodID method_id = m_env->GetStaticMethodID(callee_class,
+        method_name, method_signature);
+    ThrowOnJavaException();
+    jobject ret = m_env->CallStaticObjectMethod(callee_class, method_id);
+    ThrowOnJavaException();
+
+    return ret;
+}
+
+jobject JNIEnvWrapper::CallStaticObjectMethod(jclass callee_class,
+    const char * method_name, const char * method_signature, jobject param_1)
+{
+    jmethodID method_id = m_env->GetStaticMethodID(callee_class,
+        method_name, method_signature);
+    ThrowOnJavaException();
+    jobject ret = m_env->CallStaticObjectMethod(callee_class,
+        method_id, param_1);
+    ThrowOnJavaException();
+
+    return ret;
+}
+
+jobject JNIEnvWrapper::CallStaticObjectMethod(jclass callee_class,
+    const char * method_name, const char * method_signature, jobject param_1,
+    jobject param_2, jobject param_3)
+{
+    jmethodID method_id = m_env->GetStaticMethodID(callee_class,
+        method_name, method_signature);
+    ThrowOnJavaException();
+    jobject ret = m_env->CallStaticObjectMethod(callee_class, method_id,
+        param_1, param_2, param_3);
+    ThrowOnJavaException();
+
+    return ret;
+}
+
+jint JNIEnvWrapper::CallIntMethod(jobject callee, jclass callee_class,
+    const char * method_name, const char * method_signature, jobject param_1)
+{
+    jmethodID method_id = m_env->GetMethodID(callee_class,
+        method_name, method_signature);
+    ThrowOnJavaException();
+    jint ret = m_env->CallIntMethod(callee, method_id, param_1);
+    ThrowOnJavaException();
+    return ret;
+}
+
+void JNIEnvWrapper::CallVoidMethod(jobject callee, jclass callee_class,
+    const char * method_name, const char * method_signature)
+{
+    jmethodID method_id = m_env->GetMethodID(callee_class,
+        method_name, method_signature);
+    ThrowOnJavaException();
+    m_env->CallVoidMethod(callee, method_id);
+    ThrowOnJavaException();
+}
+
+jstring JNIEnvWrapper::NewStringUTF(const char * utf8_string)
+{
+    jstring ret = m_env->NewStringUTF(utf8_string);
+    ThrowOnJavaException();
+
+    return ret;
+}
+
+const char * JNIEnvWrapper::GetStringUTFChars(jstring string)
+{
+    return m_env->GetStringUTFChars(string, NULL);
+}
+
+void JNIEnvWrapper::ReleaseStringUTFChars(jstring string, const char * utf8_chars)
+{
+    m_env->ReleaseStringUTFChars(string, utf8_chars);
+}
+
+jbyteArray JNIEnvWrapper::NewByteArray(size_t size)
+{
+    jbyteArray ret = m_env->NewByteArray(size);
+    ThrowOnJavaException();
+
+    return ret;
+}
+
+jbyte * JNIEnvWrapper::GetByteArrayElements(jbyteArray java_array)
+{
+    return m_env->GetByteArrayElements(java_array, NULL);
+}
+
+void JNIEnvWrapper::ReleaseByteArrayElements(jbyteArray java_array,
+    jbyte * native_array)
+{
+    m_env->ReleaseByteArrayElements(java_array, native_array, 0);
+}
+
+static std::string GetTemporaryFilePath(JNIEnvWrapper& jni)
+{
+    // context = android.app.ActivityThread.currentActivityThread().getApplication()
+    jclass thread_class = jni.FindClass("android/app/ActivityThread");
+    jobject current_thread = jni.CallStaticObjectMethod(thread_class,
+        "currentActivityThread", "()Landroid/app/ActivityThread;");
+    jobject context = jni.CallObjectMethod(current_thread, thread_class,
+        "getApplication", "()Landroid/app/Application;");
+
+    // cache_dir = context.getCacheDir()
+    jclass context_class = jni.FindClass("android/content/Context");
+    jobject cache_dir = jni.CallObjectMethod(context, context_class,
+        "getCacheDir", "()Ljava/io/File;");
+
+    // temp_file = java.io.File.createTempFile("chuck_temp", "", cache_dir)
+    jclass file_class = jni.FindClass("java/io/File");
+    jobject temp_file = jni.CallStaticObjectMethod(file_class, "createTempFile",
+        "(Ljava/lang/String;Ljava/lang/String;Ljava/io/File;)Ljava/io/File;",
+        jni.NewStringUTF("chuck_temp"), jni.NewStringUTF(""), cache_dir);
+
+    // temp_file_path = temp_file.getPath()
+    jstring temp_file_path = (jstring)jni.CallObjectMethod(temp_file,
+        file_class, "getPath", "()Ljava/lang/String;");
+
+    const char * path_chars = jni.GetStringUTFChars(temp_file_path);
+    std::string ret = path_chars;
+    jni.ReleaseStringUTFChars(temp_file_path, path_chars);
+
+    return ret;
+}
+
+FILE * ChuckAndroid::getTemporaryFile() noexcept
 {
     JavaVM * jvm = getJVM();
     if( !jvm )
     {
         return NULL;
     }
-    JNIEnv * env = NULL;
-    bool needs_detaching = false;
-    int reason = jvm->GetEnv((void **)&env, JNI_VERSION_1_6);
-    if( reason != JNI_OK && reason != JNI_EDETACHED )
+    JNIEnvWrapper jni(jvm);
+    if( !jni.IsValid() )
     {
         return NULL;
     }
-    if( reason == JNI_EDETACHED )
+
+    try
     {
-        if( jvm->AttachCurrentThread(&env, NULL) != 0 )
-        {
-            return NULL;
-        }
-        needs_detaching = true;
+        const std::string temp_path = GetTemporaryFilePath(jni);
+        return fopen(temp_path.c_str(), "wb+");
+    }
+    catch (JNIEnvWrapperException)
+    {
+        return NULL;
+    }
+}
+
+bool ChuckAndroid::copyJARURLFileToTemporary(const char * jar_url, int * fd)
+    noexcept
+{
+    JavaVM * jvm = getJVM();
+    if( !jvm )
+    {
+        return false;
+    }
+    JNIEnvWrapper jni(jvm);
+    if( !jni.IsValid() )
+    {
+        return false;
     }
 
-    std::unique_ptr<JavaVM, std::function<void(JavaVM *)>> guard(jvm,
-        [needs_detaching](JavaVM *jvm)
+    int ret = 0;
+    try
+    {
+        const std::string temp_path = GetTemporaryFilePath(jni);
+        ret = open(temp_path.c_str(), O_RDWR | O_CREAT, 0600);
+        if( ret == -1 )
         {
-            if (needs_detaching)
-            {
-                jvm->DetachCurrentThread();
-            }
-        });
-
-    assert( env != NULL );
-    #define EXCEPTION_CHECK \
-        if (env->ExceptionCheck()) \
-        { \
-            env->ExceptionDescribe(); \
-            env->ExceptionClear(); \
-            return NULL; \
+            return false;
+        }
+        // do not pollute temp directory
+        if( unlink(temp_path.c_str()) == -1 )
+        {
+            return false;
         }
 
-    // context = android.app.ActivityThread.currentActivityThread().getApplication()
-    jclass thread_class = env->FindClass("android/app/ActivityThread");
-    EXCEPTION_CHECK;
-    jmethodID get_thread = env->GetStaticMethodID(
-        thread_class, "currentActivityThread", "()Landroid/app/ActivityThread;");
-    EXCEPTION_CHECK;
-    jobject current_thread = env->CallStaticObjectMethod(thread_class, get_thread);
-    EXCEPTION_CHECK;
-    jmethodID get_application = env->GetMethodID(
-        thread_class, "getApplication", "()Landroid/app/Application;");
-    EXCEPTION_CHECK;
-    jobject context = env->CallObjectMethod(current_thread, get_application);
-    EXCEPTION_CHECK;
+        // url = new java.net.URL(jar_url)
+        jclass url_class = jni.FindClass("java/net/URL");
+        jobject url = jni.ConstructNewObject(url_class,
+            "(Ljava/lang/String;)V", jni.NewStringUTF(jar_url));
 
-    // cache_dir = context.getCacheDir()
-    jclass context_class = env->FindClass("android/content/Context");
-    EXCEPTION_CHECK;
-    jmethodID get_cache_dir = env->GetMethodID(context_class, "getCacheDir", "()Ljava/io/File;");
-    EXCEPTION_CHECK;
-    jobject cache_dir = env->CallObjectMethod(context, get_cache_dir);
-    EXCEPTION_CHECK;
+        // connection = url.openConnection()
+        jobject connection = jni.CallObjectMethod(url, url_class,
+            "openConnection", "()Ljava/net/URLConnection;");
 
-    // temp_file = cache_dir.createTempFile("chuck_temp", "", cache_dir)
-    jclass file_class = env->FindClass("java/io/File");
-    EXCEPTION_CHECK;
-    jmethodID create_temp_file = env->GetStaticMethodID(file_class, "createTempFile",
-        "(Ljava/lang/String;Ljava/lang/String;Ljava/io/File;)Ljava/io/File;");
-    EXCEPTION_CHECK;
-    jobject temp_file = env->CallStaticObjectMethod(file_class, create_temp_file,
-        env->NewStringUTF("chuck_temp"), env->NewStringUTF(""), cache_dir);
-    EXCEPTION_CHECK;
+        // jar_file = (java.net.JarURLConnection)connection.getJarFile()
+        jclass jar_url_connection_class = jni.FindClass(
+            "java/net/JarURLConnection");
+        jobject jar_file = jni.CallObjectMethod(connection,
+            jar_url_connection_class, "getJarFile",
+            "()Ljava/util/jar/JarFile;");
 
-    // temp_file_path = temp_file.getPath()
-    jmethodID get_path = env->GetMethodID(file_class, "getPath", "()Ljava/lang/String;");
-    EXCEPTION_CHECK;
-    jstring temp_file_path = (jstring)env->CallObjectMethod(temp_file, get_path);
-    EXCEPTION_CHECK;
+        // jar_entry = connection.getJarEntry()
+        jobject jar_entry = jni.CallObjectMethod(connection,
+            jar_url_connection_class, "getJarEntry",
+            "()Ljava/util/jar/JarEntry;");
+        
+        // input_stream = jar_file.getInputStream(jar_entry)
+        jclass jar_file_class = jni.FindClass("java/util/jar/JarFile");
+        jobject input_stream = jni.CallObjectMethod(jar_file, jar_file_class,
+            "getInputStream", "(Ljava/util/zip/ZipEntry;)Ljava/io/InputStream;",
+            jar_entry);
 
-    const char *path_chars = env->GetStringUTFChars(temp_file_path, NULL);
-    FILE *ret = fopen(path_chars, "wb+D");
-    env->ReleaseStringUTFChars(temp_file_path, path_chars);
+        // buffer = new byte[8 * 1024]
+        jbyteArray java_buffer = jni.NewByteArray(8 * 1024);
+        // s = input_stream.read(buffer)
+        jclass input_stream_class = jni.FindClass("java/io/InputStream");
+        jint s = 0;
+        do
+        {
+            s = jni.CallIntMethod(input_stream, input_stream_class, "read",
+                "([B)I", java_buffer);
+            jbyte * native_buffer = jni.GetByteArrayElements(java_buffer);
+            size_t written = 0;
+            while( written < s )
+            {
+                ssize_t written_now = write(ret, native_buffer + written,
+                    s - written);
+                if( written_now < 0 )
+                {
+                    close(ret);
+                    return false;
+                }
+                written += written_now;
+            }
+            jni.ReleaseByteArrayElements(java_buffer, native_buffer);
+        } while( s > 0 );
 
-    return ret;
+        // jar_file.close()
+        jni.CallVoidMethod(jar_file, jar_file_class, "close", "()V");
+    }
+    catch (JNIEnvWrapperException)
+    {
+        if( ret != -1 )
+        {
+            close(ret);
+        }
+        return false;
+    }
+
+    lseek(ret, 0, SEEK_SET);
+    *fd = ret;
+    return true;
 }
 
 #endif // __ANDROID__

--- a/src/core/util_platforms.h
+++ b/src/core/util_platforms.h
@@ -42,16 +42,15 @@
 #include <jni.h>
 #include <stdio.h>
 
-
 //-----------------------------------------------------------------------------
-// name: class ChuckAndroid
+// name: namespace ChuckAndroid
 // desc: android specific ChucK utilities
 //-----------------------------------------------------------------------------
-class ChuckAndroid
+namespace ChuckAndroid
 {
-public:
-    static JavaVM * getJVM();
-    static FILE * getTemporaryFile();
+    JavaVM * getJVM();
+    FILE * getTemporaryFile() noexcept;
+    bool copyJARURLFileToTemporary(const char * jar_url, int * fd) noexcept;
 };
 
 #endif // __ANDROID__


### PR DESCRIPTION
The following set of commits allows Chuck to read files from JARs. On Android, the contents of a JAR (e.g., APK, the app files format) are referred by things that are called "JAR URLs" (they look like this: "'jar:file:///data/app/test.test/test.apk!/assets/impact.wav"). They can be read by using [JarURLConnection](https://developer.android.com/reference/java/net/JarURLConnection) class, but this is only available at the Java side, and it does not give us an actual POSIX file to read from - this gives us only the bytes of a file. (On iOS, a request to the internals of the app file would be transparently proxied by the OS, but it's not the case on Android.)

So, the following adds a C++ bridge to use JarURLConnection, puts the read contents into new temporary files, and provides these new temporary files for other Chuck utilities to read from - in case if paths that provided to Chuck, look like JAR URLs (start from "jar:"). This heuristics and this whole functionality are only enabled when compiling for Android, and should not change the behaviour on other targets.