### PR TITLE
Bugfix: MidiIn crash

### DIFF
--- a/src/core/midiio_rtmidi.cpp
+++ b/src/core/midiio_rtmidi.cpp
@@ -436,9 +436,10 @@ t_CKBOOL MidiInManager::open( MidiIn * min, Chuck_VM * vm, t_CKINT device_num )
     return TRUE;
 }
 
-t_CKBOOL MidiOutManager::close(MidiIn * min)
+t_CKBOOL MidiInManager::close(MidiIn * min)
 {
-    min->m_buffer->resign((Chuck_Event *)min->SELF);
+    min->m_buffer->resign(min->m_read_index);
+    return true;
 }
 
 t_CKBOOL MidiInManager::open( MidiIn * min, Chuck_VM * vm, const std::string & name )

--- a/src/core/midiio_rtmidi.cpp
+++ b/src/core/midiio_rtmidi.cpp
@@ -436,8 +436,10 @@ t_CKBOOL MidiInManager::open( MidiIn * min, Chuck_VM * vm, t_CKINT device_num )
     return TRUE;
 }
 
-
-
+t_CKBOOL MidiOutManager::close(MidiIn * min)
+{
+    min->m_buffer->resign((Chuck_Event *)min->SELF);
+}
 
 t_CKBOOL MidiInManager::open( MidiIn * min, Chuck_VM * vm, const std::string & name )
 {
@@ -574,8 +576,7 @@ t_CKBOOL MidiIn::close()
     if( !m_valid )
         return FALSE;
 
-    // close
-    // MidiInManager::close( this );
+    MidiInManager::close(this);
 
     m_valid = FALSE;
 
@@ -769,7 +770,6 @@ t_CKBOOL MidiOutManager::open( MidiOut * mout, t_CKINT device_num )
     // done
     return TRUE;
 }
-
 
 t_CKBOOL MidiOutManager::open( MidiOut * mout, const std::string & name )
 {


### PR DESCRIPTION
If there's a MidiIn in a shred that goes away, we were failing to unregister our event listener causing a crash on windows 64bit debugging builds.

repro case

```ck
fun void doit(int id, dur maxwait)
{
    MidiIn min;
    MidiMsg msg;
    if(!min.open(0))
    {
        <<< "MIDI device 0 can't be opened." >>>;
        me.exit();
    }

    <<< "MIDI device:", min.num(), " -> ", min.name() >>>;
    <<< "Listening for midi events for", maxwait >>>;
    now => time start;
    while(now - start < maxwait)
    {
        if(1)
        {
            min => now;
            while(min.recv(msg))
            {
                <<<"midimsg", msg.data1>>>;
            }
        }
        else
            1::second => now;
    }
    <<< "shred", id, "done" >>>;
}

spork ~ doit(1,10::second);
spork ~ doit(2,25::second);
```