### PR TITLE
Fixed sounds not loading in LiSa-load.ck example + formatting error in LiSa-munger1.ck

### DIFF
--- a/examples/special/LiSa-load.ck
+++ b/examples/special/LiSa-load.ck
@@ -15,7 +15,7 @@
 //-----------------------------------------------------------------------------
 
 // one-stop function for creating a LiSa, loaded with the specified audio file
-load( me.dir() + "twilight-granular.aiff" ) @=> LiSa @ lisa;
+load( me.dir() + "twilight/twilight-granular.aiff" ) @=> LiSa @ lisa;
 // connect
 lisa => dac;
 

--- a/examples/special/LiSa-munger1.ck
+++ b/examples/special/LiSa-munger1.ck
@@ -75,7 +75,7 @@ fun void getgrain( dur grainlen, dur rampup, dur rampdown, float rate )
     // get an available voice
     lisa.getVoice() => int newvoice;
 
-    // make sure we got a valid voice   
+    // make sure we got a valid voice   
     if( newvoice > -1 )
     {
         // set play rate


### PR DESCRIPTION
twilight-granular.aiff was moved in https://github.com/ccrma/chuck/commit/8e40065e788c2e258afe6551a08134bd2eb5e89d but LiSa-load.ck was never updated to reflect that.

There was also some extra character in LiSa-munger1.ck that I deleted: 

![image](https://user-images.githubusercontent.com/6963603/156413765-73c3a853-0784-438d-bad8-9ab1a670f2dc.png)
