### PR TITLE
Allow declaring arrays with subclasses as elements

### DIFF
--- a/src/core/chuck_type.cpp
+++ b/src/core/chuck_type.cpp
@@ -5749,6 +5749,8 @@ Chuck_Type * new_array_type( Chuck_Env * env, Chuck_Type * array_parent,
     Chuck_Type * base_curr = base_type->parent;
     Chuck_Type * t_curr = t;
 
+    // 1.4.1.1 (nshaheed) added to allow declaring arrays with subclasses as elements (PR #211)
+    // example: [ new SinOsc, new Sinosc ] @=> Osc arr[]; // this previously would fail type check
     while (base_curr != NULL) {
       Chuck_Type * new_parent = new_array_element_type(env, base_curr, depth, owner_nspc);
       t_curr->parent = new_parent;
@@ -5784,7 +5786,7 @@ Chuck_Type * new_array_type( Chuck_Env * env, Chuck_Type * array_parent,
 
 //-----------------------------------------------------------------------------
 // name: new_array_element_type()
-// desc: instantiate new chuck type for use in arrays (nshaheed)
+// desc: instantiate new chuck type for use in arrays (nshaheed) added
 //-----------------------------------------------------------------------------
 Chuck_Type * new_array_element_type( Chuck_Env * env, Chuck_Type * base_type,
 		       t_CKUINT depth, Chuck_Namespace * owner_nspc)
@@ -6755,8 +6757,11 @@ void Chuck_Type::apropos( std::string & output )
     Chuck_Type * type = this;
     // only the first
     t_CKBOOL inherited = FALSE;
+
     // handle arrays special
-    if( this->array_type )
+    // 1.4.1.1 (ge + nshaheed) if -> while; to skip intermediate array types,
+    // which were added to handle array type-checking (see new_array_element_type())
+    while( type->array_type )
     {
         // skip current one, which extend @array to avoid printing duplicates
         type = type->parent;

--- a/src/core/chuck_type.h
+++ b/src/core/chuck_type.h
@@ -907,6 +907,9 @@ t_CKBOOL verify_array( a_Array_Sub array );
 Chuck_Type * new_array_type( Chuck_Env * env, Chuck_Type * array_parent,
                              t_CKUINT depth, Chuck_Type * base_type,
                              Chuck_Namespace * owner_nspc );
+// make type
+Chuck_Type * new_array_element_type( Chuck_Env * env, Chuck_Type * base_type,
+		       t_CKUINT depth, Chuck_Namespace * owner_nspc);
 // conversion
 const char * type_path( a_Id_List path );
 a_Id_List str2list( const std::string & path );

--- a/src/core/chuck_type.h
+++ b/src/core/chuck_type.h
@@ -907,7 +907,7 @@ t_CKBOOL verify_array( a_Array_Sub array );
 Chuck_Type * new_array_type( Chuck_Env * env, Chuck_Type * array_parent,
                              t_CKUINT depth, Chuck_Type * base_type,
                              Chuck_Namespace * owner_nspc );
-// make type
+// make type | 1.4.1.1 (nshaheed) added
 Chuck_Type * new_array_element_type( Chuck_Env * env, Chuck_Type * base_type,
 		       t_CKUINT depth, Chuck_Namespace * owner_nspc);
 // conversion

--- a/src/test/01-Basic/92.ck
+++ b/src/test/01-Basic/92.ck
@@ -1,0 +1,13 @@
+// ensure an array can different subclasses of its declared type
+[new SinOsc, new SinOsc, new TriOsc] @=> UGen a[];
+[new SinOsc, new SinOsc, new SinOsc] @=> UGen b[];
+[new SinOsc] @=> UGen c[];
+UGen d[0];
+[new SinOsc, new Event] @=> Object e[];
+
+a << new Noise;
+d << new Noise << new SinOsc;
+
+if (a.size() != 4) <<< "test failed" >>>;
+else if (d.size() != 2) <<< "test failed" >>>;
+else <<< "success" >>>;

--- a/src/test/01-Basic/92.ck
+++ b/src/test/01-Basic/92.ck
@@ -1,13 +1,14 @@
 // ensure an array can different subclasses of its declared type
 [new SinOsc, new SinOsc, new TriOsc] @=> UGen a[];
-[new SinOsc, new SinOsc, new SinOsc] @=> UGen b[];
-[new SinOsc] @=> UGen c[];
-UGen d[0];
-[new SinOsc, new Event] @=> Object e[];
+[new SinOsc, new SinOsc, new TriOsc] @=> Osc b[];
+[new SinOsc, new SinOsc, new SinOsc] @=> UGen c[];
+[new SinOsc] @=> UGen d[];
+UGen e[0];
+[new SinOsc, new Event] @=> Object f[];
 
 a << new Noise;
-d << new Noise << new SinOsc;
+e << new Noise << new SinOsc;
 
 if (a.size() != 4) <<< "test failed" >>>;
-else if (d.size() != 2) <<< "test failed" >>>;
+else if (e.size() != 2) <<< "test failed" >>>;
 else <<< "success" >>>;


### PR DESCRIPTION
This fixes a bug that caused an array declaration filled with subclasses, like this:

`[new SinOsc, new SinOsc, new TriOsc] @=> UGen a[];`

to wrongly throw a type error 