### PR TITLE
add shred.realtime() - detect whether a shred is running in realtime

### DIFF
--- a/src/core/chuck_lang.cpp
+++ b/src/core/chuck_lang.cpp
@@ -537,6 +537,11 @@ t_CKBOOL init_class_shred( Chuck_Env * env, Chuck_Type * type )
     func->doc = "get the enclosing directory, the specified number of parent directories up.";
     if( !type_engine_import_mfun( env, func ) ) goto error;
 
+    // add realtime() (added 1.4.1.3, nshaheed)
+    func = make_new_mfun( "int", "realtime", shred_realtime );
+    func->doc = "return true if the shred is in realtime mode, false if it's in silent mode (i.e. --silent is enabled)";
+    if( !type_engine_import_mfun( env, func ) ) goto error;
+
     // end the class import
     type_engine_import_class_end( env );
 
@@ -1893,6 +1898,11 @@ CK_DLL_MFUN( shred_sourceDir2 ) // added 1.3.2.0
     str->set( dir_go_up( str->str(), i ) );
 
     RETURN->v_string = str;
+}
+
+CK_DLL_MFUN( shred_realtime ) // added 1.4.1.3 (nshaheed)
+{
+    RETURN->v_int = SHRED->vm_ref->env()->is_realtime_audio();
 }
 
 

--- a/src/core/chuck_lang.h
+++ b/src/core/chuck_lang.h
@@ -165,6 +165,7 @@ CK_DLL_MFUN( shred_getArg );
 CK_DLL_MFUN( shred_sourcePath ); // added 1.3.0.0
 CK_DLL_MFUN( shred_sourceDir ); // added 1.3.0.0
 CK_DLL_MFUN( shred_sourceDir2 ); // added 1.3.2.0
+CK_DLL_MFUN( shred_realtime ); // added 1.4.1.3 (nshaheed)
 CK_DLL_SFUN( shred_fromId ); // added 1.3.2.0
 
 

--- a/src/core/chuck_type.h
+++ b/src/core/chuck_type.h
@@ -511,6 +511,9 @@ public:
     t_CKBOOL is_global()
     { return class_def == NULL && func == NULL && class_scope == 0; }
 
+    t_CKBOOL is_realtime_audio()
+    { return m_carrier->hintIsRealtimeAudio(); }
+
 public:
     // REFACTOR-2017: public types
     Chuck_Type * t_void;

--- a/src/test/01-Basic/113.ck
+++ b/src/test/01-Basic/113.ck
@@ -1,0 +1,5 @@
+// Tests whether realtime successfully detects if ChucK is in silent mode
+
+if (!me.realtime()) {
+    <<< "success" >>>;
+}


### PR DESCRIPTION
me.realtime() will detect whether the current shred is running in realtime (i.e. me.realtime() == false means that --silent is enabled). Useful for when you need to do something different in offline mode!