### PR TITLE
Make ObjectAPI methods public

### DIFF
--- a/src/core/chuck_dl.h
+++ b/src/core/chuck_dl.h
@@ -675,7 +675,7 @@ public:
     struct ObjectApi
     {
         ObjectApi();
-    private:
+    public:
         // function pointer get_type()
         Type (* const get_type)( CK_DL_API, Chuck_VM_Shred *, std::string &name );
         // function pointer create()


### PR DESCRIPTION
So the object api was made private in 0f3af332c31f51c28ba7cccc8d05d388492fcd85 despite the fact that the vm api is public. I was wondering if there was any context as to why this happened? This looks super useful for making chugins and it seems necessary to me for doing things like returning strings (https://github.com/ccrma/chugins/issues/46)

