### PR TITLE
Fix compile error when returning from a void function

### DIFF
--- a/src/core/chuck_emit.cpp
+++ b/src/core/chuck_emit.cpp
@@ -1331,7 +1331,7 @@ t_CKBOOL emit_engine_emit_return( Chuck_Emitter * emit, a_Stmt_Return stmt )
         return FALSE;
 
     // if return is an object type
-    if( isobj( emit->env, stmt->val->type ) )
+    if( stmt->val && isobj( emit->env, stmt->val->type ) )
     {
         // add reference (to be released by the function caller)
         emit->append( new Chuck_Instr_Reg_AddRef_Object3 );

--- a/src/test/01-Basic/121.ck
+++ b/src/test/01-Basic/121.ck
@@ -1,0 +1,7 @@
+// test to make sure that return works in a void function
+fun void test() {
+	return;
+}
+
+test();
+<<< "success" >>>;


### PR DESCRIPTION
f67b5be introduced a bug where a void function with an explicit return would fail at the compilation stage. This is because stmt->val is null in this situation.