### PR TITLE
Add negative array indexing (ala python)

### DIFF
--- a/src/core/chuck_instr.cpp
+++ b/src/core/chuck_instr.cpp
@@ -5701,7 +5701,11 @@ error:
 }
 
 
+t_CKINT normalize_index(t_CKINT i, t_CKINT len) {
+    if (i >= 0) return i; // a normal array index
 
+    return len + i; // start with len-1 and keep going down
+}
 
 //-----------------------------------------------------------------------------
 // name: execute()
@@ -5735,6 +5739,7 @@ void Chuck_Instr_Array_Access::execute( Chuck_VM * vm, Chuck_VM_Shred * shred )
         Chuck_Array4 * arr = (Chuck_Array4 *)(*sp);
         // get index
         i = (t_CKINT)(*(sp+1));
+        i = normalize_index(i, arr->size());
         // check if writing
         if( m_emit_addr ) {
             // get the addr
@@ -5757,6 +5762,7 @@ void Chuck_Instr_Array_Access::execute( Chuck_VM * vm, Chuck_VM_Shred * shred )
         Chuck_Array8 * arr = (Chuck_Array8 *)(*sp);
         // get index
         i = (t_CKINT)(*(sp+1));
+        i = normalize_index(i, arr->size());
         // check if writing
         if( m_emit_addr ) {
             // get the addr
@@ -5779,6 +5785,7 @@ void Chuck_Instr_Array_Access::execute( Chuck_VM * vm, Chuck_VM_Shred * shred )
         Chuck_Array16 * arr = (Chuck_Array16 *)(*sp);
         // get index
         i = (t_CKINT)(*(sp+1));
+        i = normalize_index(i, arr->size());
         // check if writing
         if( m_emit_addr ) {
             // get the addr
@@ -5800,7 +5807,8 @@ void Chuck_Instr_Array_Access::execute( Chuck_VM * vm, Chuck_VM_Shred * shred )
         // get array
         Chuck_Array24 * arr = (Chuck_Array24 *)(*sp);
         // get index
-        i = (t_CKINT)(*(sp+1));
+        i = (t_CKINT)(*(sp + 1));
+        i = normalize_index(i, arr->size());
         // check if writing
         if( m_emit_addr ) {
             // get the addr
@@ -5823,6 +5831,7 @@ void Chuck_Instr_Array_Access::execute( Chuck_VM * vm, Chuck_VM_Shred * shred )
         Chuck_Array32 * arr = (Chuck_Array32 *)(*sp);
         // get index
         i = (t_CKINT)(*(sp+1));
+        i = normalize_index(i, arr->size());
         // check if writing
         if( m_emit_addr ) {
             // get the addr

--- a/src/test/01-Basic/122.ck
+++ b/src/test/01-Basic/122.ck
@@ -1,0 +1,10 @@
+// Negative array index access tests
+
+[1,2,3,4] @=> int a[];
+
+
+if (a[-1] != 4) <<< "FAILURE, expecting 4" >>>;
+if (a[-4] != 1) <<< "FAILURE, expecting 1" >>>;
+
+// array out of bounds
+a[-5];

--- a/src/test/01-Basic/122.txt
+++ b/src/test/01-Basic/122.txt
@@ -1,0 +1,1 @@
+[chuck](VM): ArrayOutofBounds: on line[10] in shred[id=1:01-Basic/122.ck], index=[-1]


### PR DESCRIPTION
Do you hate writing `arr[arr.size()-1]`? Cuz I sure do

Add negative array indexing just like python

```
[1,2,3,4] @=> int a[];
a[-1]; // returns 4
a[-3]; // returns 2
```