### PR TITLE
Properly scale asymmetric input/outputs in multichannel ugens

### DIFF
--- a/src/core/chuck_ugen.cpp
+++ b/src/core/chuck_ugen.cpp
@@ -933,7 +933,7 @@ t_CKBOOL Chuck_UGen::system_tick( t_CKTIME now )
             }
 
             // scale multi
-            multi /= m_multi_chan_size;
+            multi /= m_num_ins;
             m_sum += multi;
         }
     }
@@ -972,7 +972,7 @@ t_CKBOOL Chuck_UGen::system_tick( t_CKTIME now )
             if( !m_valid ) memset( m_multi_out_v, 0, sizeof(SAMPLE)*m_multi_chan_size );
 
             // supply multichannel tick output to output channels (added 1.3.0.0)
-            for( i = 0; i < m_multi_chan_size; i++ )
+            for( i = 0; i < m_num_outs; i++ )
             {
                 ugen = m_multi_chan[i];
                 // apply gain/pan
@@ -1012,7 +1012,7 @@ t_CKBOOL Chuck_UGen::system_tick( t_CKTIME now )
         }
 
         // compute mono mixdown for owner-ugen
-        multi /= m_multi_chan_size;
+        multi /= m_num_outs; // m_multi_chan_size
         // set current to mono mixdown
         m_current = multi;
         // set last to current

--- a/src/core/chuck_ugen.h
+++ b/src/core/chuck_ugen.h
@@ -109,6 +109,7 @@ public:
     void init_subgraph();
 
 public: // data
+    // List of source UGens inputting into the UGen (i.e. source_ugen => curr_ugen)
     Chuck_UGen ** m_src_list;
     t_CKUINT m_src_cap;
     t_CKUINT m_num_src;

--- a/src/core/ugen_xxx.h
+++ b/src/core/ugen_xxx.h
@@ -62,12 +62,14 @@ CK_DLL_TICK( bunghole_tick );
 // pan2
 CK_DLL_CTOR( pan2_ctor );
 CK_DLL_DTOR( pan2_dtor );
+CK_DLL_TICKF( pan2_tickf );
 CK_DLL_CTRL( pan2_ctrl_value );
 CK_DLL_CGET( pan2_cget_value );
 
 // MIX2
 CK_DLL_CTOR( mix2_ctor );
 CK_DLL_CTOR( mix2_dtor );
+CK_DLL_TICKF( mix2_tickf );
 CK_DLL_CTRL( mix2_ctrl_value );
 CK_DLL_CGET( mix2_cget_value );
 

--- a/src/test/02-UGens/Mix2.ck
+++ b/src/test/02-UGens/Mix2.ck
@@ -1,6 +1,10 @@
-Mix2 u => blackhole;
+Step step[2] => Mix2 u => blackhole;
 1::samp => now;
+
+u.last() => float last;
+
 u =< blackhole;
 null @=> u;
 
-<<< "success" >>>;
+if (last == 1.0)
+   <<< "success" >>>;

--- a/src/test/02-UGens/Pan2.ck
+++ b/src/test/02-UGens/Pan2.ck
@@ -1,4 +1,4 @@
-Step step[2] => Pan2 u => blackhole;
+Step step => Pan2 u => blackhole;
 1::samp => now;
 
 u.last() => float last;

--- a/src/test/02-UGens/Pan2.ck
+++ b/src/test/02-UGens/Pan2.ck
@@ -1,6 +1,11 @@
-Pan2 u => blackhole;
+Step step[2] => Pan2 u => blackhole;
 1::samp => now;
+
+u.last() => float last;
+u.chan(0).last() => float last_left;
+
 u =< blackhole;
 null @=> u;
 
-<<< "success" >>>;
+if (last == last_left)
+   <<< "success" >>>;


### PR DESCRIPTION
Previously, chuck would scale multichannel ugen outputs based off of `max(num_inputs, num_outputs)`, so in the case where the input and output channels are asymmetric unexpected things will happen with the output:

i.e. with 64 inputs, and 1 output, the output gain would only be 1/64th of the desired output (unless the output was mirrored across all 64 channels)