### PR TITLE
Fix building with Pipewire's JACK headers

### DIFF
--- a/src/core/makefile.x/makefile.jack
+++ b/src/core/makefile.x/makefile.jack
@@ -1,5 +1,6 @@
 
 CFLAGS+= -D__UNIX_JACK__ -D__PLATFORM_LINUX__ -fno-strict-aliasing -D__CK_SNDFILE_NATIVE__
+CFLAGS+= $(shell pkg-config --cflags jack)
 
 ifneq ($(CHUCK_DEBUG),)
 CFLAGS+= -g
@@ -7,4 +8,4 @@ else
 CFLAGS+= -O3
 endif
 
-LDFLAGS+= -lasound -ljack -lstdc++ -ldl -lm -lsndfile -lpthread
+LDFLAGS+= -lasound $(shell pkg-config --libs jack) -lstdc++ -ldl -lm -lsndfile -lpthread


### PR DESCRIPTION
ChucK currently fails to build with Pipewire's JACK headers. This PR uses pkg-config to get all necessary compilation and linking flags for the JACK dependency. This change introduces `-D_REENTRANT` to the compiler flags on my Fedora 38 system. `-D_REENTRANT` historically chose the multithreading version of some system libraries. This is mostly irrelevant today, but might fix some old or obscure platforms or libraries.