### PR TITLE
fix unusable JACK devices with special characters in name

### DIFF
--- a/src/host/RtAudio/RtAudio.h
+++ b/src/host/RtAudio/RtAudio.h
@@ -933,6 +933,7 @@ public:
   bool callbackEvent( unsigned long nframes );
 
   private:
+  std::string escape_regex_pattern( const std::string & s );
 
   bool probeDeviceOpen( unsigned int device, StreamMode mode, unsigned int channels, 
                         unsigned int firstChannel, unsigned int sampleRate,


### PR DESCRIPTION
Add simple utility method to escape (extended) regular expression meta characters in retrieved JACK device/port names.

Use only escaped/quoted port names in `jack_get_ports()` as a `port_name_pattern` argument to match a port's name _exactly_.

Fixes #331.