### PR TITLE
Std.getenv(key, default_value) variant

### DIFF
--- a/src/core/ulib_std.cpp
+++ b/src/core/ulib_std.cpp
@@ -259,8 +259,13 @@ DLL_QUERY libstd_query( Chuck_DL_Query * QUERY )
 
     // add getenv
     QUERY->add_sfun( QUERY, getenv_impl, "string", "getenv" ); //! fetch environment variable
-    QUERY->add_arg( QUERY, "string", "value" );
-    QUERY->doc_func( QUERY, "get the value of an environment variable (e.g., PATH)." );
+    QUERY->add_arg( QUERY, "string", "key" );
+    QUERY->doc_func( QUERY, "get the value of an environment variable (e.g. PATH)." );
+
+    QUERY->add_sfun( QUERY, getenv2_impl, "string", "getenv" ); //! fetch environment variable
+    QUERY->add_arg( QUERY, "string", "key" );
+    QUERY->add_arg( QUERY, "string", "default" );
+    QUERY->doc_func( QUERY, "get the value of an environment variable, returning the provided default if unset." );
 
     // add setenv
     QUERY->add_sfun( QUERY, setenv_impl, "int", "setenv" ); //! set environment variable
@@ -806,7 +811,22 @@ CK_DLL_SFUN( getenv_impl )
     RETURN->v_string = a;
 }
 
-// setenv
+// getenv with default value fallback.
+CK_DLL_SFUN( getenv2_impl )
+{
+    const char * k = GET_NEXT_STRING(ARGS)->str().c_str();
+    const char * v = getenv( k );
+    if (v) {
+        Chuck_String * a = (Chuck_String *)instantiate_and_initialize_object( SHRED->vm_ref->env()->t_string, SHRED );
+        a->set( v ? v : "" );
+        RETURN->v_string = a;
+    } else {
+        Chuck_String * d = GET_CK_STRING(ARGS);
+        RETURN->v_string = d;
+    }
+}
+
+/// setenv
 CK_DLL_SFUN( setenv_impl )
 {
     const char * v1 = GET_NEXT_STRING(ARGS)->str().c_str();

--- a/src/core/ulib_std.h
+++ b/src/core/ulib_std.h
@@ -53,6 +53,7 @@ CK_DLL_SFUN( itoa_impl );
 CK_DLL_SFUN( ftoa_impl );
 CK_DLL_SFUN( ftoi_impl );
 CK_DLL_SFUN( getenv_impl );
+CK_DLL_SFUN( getenv2_impl );
 CK_DLL_SFUN( setenv_impl );
 
 CK_DLL_SFUN( mtof_impl );

--- a/src/test/01-Basic/173-getenv2.ck
+++ b/src/test/01-Basic/173-getenv2.ck
@@ -1,9 +1,0 @@
-// Verify that the 2 argument form of std.getenv returns the default value when the
-// requested environment variable does not exist.
-
-"C28FBF4D-CAF9-4180-B875-C9B9B768DDA5" => string env_key;
-"Charles Edward Anderson Berry" => string default_value;
-
-Std.getenv(env_key, default_value) => string env_value;
-
-if ( env_value == default_value ) <<< "success" >>>;

--- a/src/test/01-Basic/173-getenv2.ck
+++ b/src/test/01-Basic/173-getenv2.ck
@@ -1,0 +1,9 @@
+// Verify that the 2 argument form of std.getenv returns the default value when the
+// requested environment variable does not exist.
+
+"C28FBF4D-CAF9-4180-B875-C9B9B768DDA5" => string env_key;
+"Charles Edward Anderson Berry" => string default_value;
+
+Std.getenv(env_key, default_value) => string env_value;
+
+if ( env_value == default_value ) <<< "success" >>>;

--- a/src/test/01-Basic/177-getenv2.ck
+++ b/src/test/01-Basic/177-getenv2.ck
@@ -1,0 +1,16 @@
+// verify that the 2 argument form of std.getenv returns the default 
+// value when the requested environment variable does not exist.
+
+// key
+"C28FBF4D-CAF9-4180-B875-C9B9B768DDA5" => string env_key;
+// default
+"Charles Edward Anderson Berry" => string default_value;
+
+// with default
+Std.getenv(env_key, default_value) => string env_value1;
+// test null
+Std.getenv(null, default_value) => string env_value2;
+
+// verify
+if ( env_value1 == default_value &&
+     env_value2 == default_value ) <<< "success" >>>;


### PR DESCRIPTION
A simple 2 argument variant of Std.getenv where the second string argument is the default value returned if the requested environment variable is unset.

Simplifies
```
Std.getenv("COOL_PROG_OSC_ADDRESS") => string addr;
if (addr == "") {
  "127.0.0.1" => addr;
}
```
to
`Std.getenv("COOL_PROG_OSC_ADDRESS", "127.0.0.1") => string osc_in_port;`