### PR TITLE
--pid-file:<path> CLI option

### DIFF
--- a/src/host/chuck_main.cpp
+++ b/src/host/chuck_main.cpp
@@ -1092,8 +1092,6 @@ t_CKBOOL go( int argc, const char ** argv )
     {
         // print error
         EM_error2( 0, "no input files... (try --help/-h)" );
-        // clean up
-        global_cleanup();
         // done
         EXIT_with_global_cleanup( 1 );
     }

--- a/src/host/chuck_main.cpp
+++ b/src/host/chuck_main.cpp
@@ -399,6 +399,13 @@ t_CKBOOL global_cleanup()
     // 1.5.0.0 (ge) | commented
     // s_mutex.release();
 
+    // delete process id file.
+    if( g_pidfile )
+    {
+        unlink( g_pidfile );
+        g_pidfile = NULL;
+    }
+
     return TRUE;
 }
 


### PR DESCRIPTION
This PR adds a `--pid-file:<path>` to Chuck host.

When provided on MacOS or Linux, Chuck will try to write it's process ID to the given file upon startup, and then remove that file upon shutdown. This assists external process supervision (through tools like monit,etc) for long-running installations that need auto-rebooting, instant kill switches for live performances, and other programmatic external process control.

1. I haven't implemented this for Windows at this time, because I don't presently have a Win box to verify that a call to the appropriate API (DWORD GetCurrentProcessId() in <processthreadsapi.h>) won't break your build.

1.  Is there somewhere to document the CLI options in the new clean 1.5.0.x build? (Great work on the clean-up, btw).