### PR TITLE
add system error messages for chugin dlerrors on windows

### DIFF
--- a/VERSIONS
+++ b/VERSIONS
@@ -2,6 +2,14 @@
 ChucK VERSIONS log
 ------------------
 
+1.5.1.4
+=======
+- (fixed) on Windows and --verbose level SYSTEM or higher, when a chugin 
+    fails to load, instead of displaying a cryptic error code (e.g., 
+    "reason: 1920"), the error code is translating into an error message 
+    and displayed (azaday)
+
+
 1.5.1.3 (September 2023) "ChucK to School"
 =======
 (note) this release of chuck addresses a number of issues from long-time 

--- a/VERSIONS
+++ b/VERSIONS
@@ -7,7 +7,8 @@ ChucK VERSIONS log
 - (fixed) on Windows and --verbose level SYSTEM or higher, when a chugin 
     fails to load, instead of displaying a cryptic error code (e.g., 
     "reason: 1920"), the error code is translating into an error message 
-    and displayed (azaday)
+    and displayed (e.g., "reason: The file cannot be accessed by the system.")
+    (azaday)
 
 
 1.5.1.3 (September 2023) "ChucK to School"

--- a/src/core/chuck_dl.cpp
+++ b/src/core/chuck_dl.cpp
@@ -1594,6 +1594,7 @@ array4_get_key(ck_array4_get_key)
 
 // windows
 #if defined(__PLATFORM_WINDOWS__)
+#include <system_error>
 extern "C"
 {
 #ifndef __CHUNREAL_ENGINE__
@@ -1631,7 +1632,9 @@ const char * dlerror( void )
     int error = GetLastError();
     if( error == 0 ) return NULL;
     // 1.4.2.0 (ge) | changed to snprintf
-    snprintf( dlerror_buffer, DLERROR_BUFFER_LENGTH, "%i", error );
+    // 1.5.1.3 (azaday) | convert error code to system message
+    std::string error_msg = std::system_category().message(error);
+    snprintf( dlerror_buffer, DLERROR_BUFFER_LENGTH, "%s", error_msg.c_str() );
     return dlerror_buffer;
 }
 }

--- a/src/core/chuck_dl.cpp
+++ b/src/core/chuck_dl.cpp
@@ -1594,7 +1594,7 @@ array4_get_key(ck_array4_get_key)
 
 // windows
 #if defined(__PLATFORM_WINDOWS__)
-#include <system_error>
+#include <system_error> // std::system_category() | 1.5.1.4
 extern "C"
 {
 #ifndef __CHUNREAL_ENGINE__
@@ -1629,12 +1629,15 @@ void *dlsym( void * handle, const char *symbol )
 
 const char * dlerror( void )
 {
+    // get windows error code
     int error = GetLastError();
+    // no error
     if( error == 0 ) return NULL;
-    // 1.4.2.0 (ge) | changed to snprintf
-    // 1.5.1.3 (azaday) | convert error code to system message
-    std::string error_msg = std::system_category().message(error);
+    // 1.5.1.4 (azaday) convert error code to system message
+    std::string error_msg = std::system_category().message( error );
+    // 1.4.2.0 (ge) changed to snprintf
     snprintf( dlerror_buffer, DLERROR_BUFFER_LENGTH, "%s", error_msg.c_str() );
+    // return error buffer
     return dlerror_buffer;
 }
 }

--- a/src/core/chuck_dl.h
+++ b/src/core/chuck_dl.h
@@ -774,8 +774,9 @@ private:
           void * dlsym( void * handle, const char * symbol );
           const char * dlerror( void );
           int dlclose( void * handle );
-          // 1.4.2.0 (ge) | added DLERROR_BUFFER_LENGTH
-          #define DLERROR_BUFFER_LENGTH 128
+          // 1.4.2.0 (ge) added DLERROR_BUFFER_LENGTH
+          // 1.5.1.4 (ge) increased DLERROR_BUFFER_LENGTH from 128 to 512
+          #define DLERROR_BUFFER_LENGTH 512
           static char dlerror_buffer[DLERROR_BUFFER_LENGTH];
 
           #ifdef __cplusplus


### PR DESCRIPTION
e.g. resolves error code 1920 to "The file cannot be accessed by the system"
Reference: https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-formatmessage