### PR TITLE
add functionality for shreds to set child stack size hint

### DIFF
--- a/src/core/chuck_instr.cpp
+++ b/src/core/chuck_instr.cpp
@@ -4103,10 +4103,14 @@ Chuck_Object * instantiate_and_initialize_object( Chuck_Type * type, Chuck_VM_Sh
             Chuck_VM_Shred * newShred = new Chuck_VM_Shred();
             // set vm_ref
             newShred->vm_ref = vm;
-            // initialize shred | 1.5.1.4 (ge) added
-            if( !newShred->initialize( NULL ) ) goto error;
-            // copy to object reference
+            // copy to object reference (in case of error, object will be deleted)
             object = newShred;
+
+            // get stack size hints | 1.5.1.4
+            t_CKINT mems = shred ? shred->childGetMemSize() : 0;
+            t_CKINT regs = shred ? shred->childGetRegSize() : 0;
+            // initialize shred | 1.5.1.4 (ge) added, along with child mem and reg stack size hints
+            if( !newShred->initialize( NULL, mems, regs ) ) goto error;
         }
         // 1.5.0.0 (ge) added -- here my feeble brain starts leaking out of my eyeballs
         else if( isa( type, vm->env()->ckt_class ) ) object = new Chuck_Type( vm->env(), te_class, type->base_name, type, type->size );

--- a/src/core/chuck_lang.cpp
+++ b/src/core/chuck_lang.cpp
@@ -558,6 +558,28 @@ t_CKBOOL init_class_shred( Chuck_Env * env, Chuck_Type * type )
     func->doc = "get the enclosing directory, the specified number of parent directories up.";
     if( !type_engine_import_mfun( env, func ) ) goto error;
 
+    // add childMemSize() | 1.5.1.4
+    func = make_new_mfun( "int", "childMemSize", shred_ctrl_hintChildMemSize );
+    func->add_arg( "int", "sizeInBytes" );
+    func->doc = "set size hint of per-shred call stack (\"mem\") for children shreds subsequently sporked from the calling shred (NOTE this size hint does not affect the calling shred--only its descendants); if sizeInBytes <= 0, the size hint is set to the VM default. (FYI This is an arcane functionality that most programmers never need to worry about. Advanced usage: set size hint to small values (e.g., 1K) to support A LOT (e.g., >10000) of simultaneous shreds; set size hint to large values (e.g., >65K) to spork functions with extremely deep recursion, or to support A LOT (>10000) of declared local variables. Use with care.)";
+    if( !type_engine_import_mfun( env, func ) ) goto error;
+
+    // add childMemSize() | 1.5.1.4
+    func = make_new_mfun( "int", "childMemSize", shred_cget_hintChildMemSize );
+    func->doc = "get the memory stack size hint (in bytes) for shreds sporked from this one.";
+    if( !type_engine_import_mfun( env, func ) ) goto error;
+
+    // add childRegSize() | 1.5.1.4
+    func = make_new_mfun( "int", "childRegSize", shred_ctrl_hintChildRegSize );
+    func->add_arg( "int", "sizeInBytes" );
+    func->doc = "set size hint of per-shred operand stack (\"reg\") for children shreds subsequently sporked from the calling shred (NOTE this size hint does not affect the calling shred--only its descendants); if sizeInBytes <= 0, the size hint is set to the VM default. (FYI This is an arcane functionality that most programmers never need to worry about. Advanced usage: set size hint to small values (e.g., 256 bytes) to support A LOT (>10000) of simultaneous shreds; set size hint to large values (e.g., >20K) to spork functions with extremely lengthy (>10000) statements, including array initializer lists. Use with care.)";
+    if( !type_engine_import_mfun( env, func ) ) goto error;
+
+    // add childRegSize() | 1.5.1.4
+    func = make_new_mfun( "int", "childRegSize", shred_cget_hintChildRegSize );
+    func->doc = "get the operand stack size hint (in bytes) for shreds sporked from this one.";
+    if( !type_engine_import_mfun( env, func ) ) goto error;
+
     // add examples
     if( !type_engine_import_add_ex( env, "shred/powerup.ck" ) ) goto error;
     if( !type_engine_import_add_ex( env, "shred/spork.ck" ) ) goto error;
@@ -2342,6 +2364,38 @@ CK_DLL_SFUN( shred_fromId ) // added 1.3.2.0
     Chuck_VM_Shred * derhs = SHRED->vm_ref->shreduler()->lookup(shred_id);
 
     RETURN->v_object = derhs;
+}
+
+
+CK_DLL_MFUN( shred_ctrl_hintChildMemSize ) // 1.5.1.4
+{
+    // get arg
+    t_CKINT sizeInBytes = GET_NEXT_INT(ARGS);
+    // set
+    RETURN->v_int = SHRED->childSetMemSize( sizeInBytes );
+}
+
+
+CK_DLL_MFUN( shred_cget_hintChildMemSize ) // 1.5.1.4
+{
+    // set
+    RETURN->v_int = SHRED->childGetMemSize();
+}
+
+
+CK_DLL_MFUN( shred_ctrl_hintChildRegSize ) // 1.5.1.4
+{
+    // get arg
+    t_CKINT sizeInBytes = GET_NEXT_INT(ARGS);
+    // set
+    RETURN->v_int = SHRED->childSetRegSize( sizeInBytes );
+}
+
+
+CK_DLL_MFUN( shred_cget_hintChildRegSize ) // 1.5.1.4
+{
+    // set
+    RETURN->v_int = SHRED->childGetRegSize();
 }
 
 

--- a/src/core/chuck_lang.h
+++ b/src/core/chuck_lang.h
@@ -168,6 +168,10 @@ CK_DLL_MFUN( shred_sourcePath ); // added 1.3.0.0
 CK_DLL_MFUN( shred_sourceDir ); // added 1.3.0.0
 CK_DLL_MFUN( shred_sourceDir2 ); // added 1.3.2.0
 CK_DLL_SFUN( shred_fromId ); // added 1.3.2.0
+CK_DLL_MFUN( shred_ctrl_hintChildMemSize ); // added 1.5.1.4
+CK_DLL_MFUN( shred_cget_hintChildMemSize ); // added 1.5.1.4
+CK_DLL_MFUN( shred_ctrl_hintChildRegSize ); // added 1.5.1.4
+CK_DLL_MFUN( shred_cget_hintChildRegSize ); // added 1.5.1.4
 
 
 //-----------------------------------------------------------------------------

--- a/src/core/chuck_vm.h
+++ b/src/core/chuck_vm.h
@@ -53,8 +53,8 @@
 //-----------------------------------------------------------------------------
 // vm defines
 //-----------------------------------------------------------------------------
-#define CVM_MEM_STACK_SIZE          (0x1 << 16)
-#define CVM_REG_STACK_SIZE          (0x1 << 14)
+#define CKVM_MEM_STACK_SIZE          (0x1 << 16)
+#define CKVM_REG_STACK_SIZE          (0x1 << 14)
 
 
 // forward references
@@ -172,8 +172,8 @@ public:
 
     // initialize shred
     t_CKBOOL initialize( Chuck_VM_Code * c,
-                         t_CKUINT mem_st_size = CVM_MEM_STACK_SIZE,
-                         t_CKUINT reg_st_size = CVM_REG_STACK_SIZE );
+                         t_CKUINT mem_st_size = 0,
+                         t_CKUINT reg_st_size = 0 );
     // shutdown shred
     t_CKBOOL shutdown();
     // run the shred on vm
@@ -191,6 +191,14 @@ public:
     // add get shred id | 1.5.0.8 (ge)
     t_CKUINT get_id() const { return this->xid; }
 
+    // affects children shreds sporked from this one
+    // mem is memory / call stack (for local vars)
+    t_CKINT childSetMemSize( t_CKINT sizeInBytes );
+    t_CKINT childGetMemSize( );
+    // reg is rester / operand stack (for evaluating expressions)
+    t_CKINT childSetRegSize( t_CKINT sizeInBytes );
+    t_CKINT childGetRegSize( );
+
     #ifndef __DISABLE_SERIAL__
     // HACK - spencer (added 1.3.2.0)
     // add/remove SerialIO devices to close on shred exit
@@ -203,9 +211,9 @@ public:
 // data
 //-----------------------------------------------------------------------------
 public: // machine components
-    // stacks
-    Chuck_VM_Stack * mem;
-    Chuck_VM_Stack * reg;
+    // stacks; mem for "memory" and reg for "register"
+    Chuck_VM_Stack * mem; // call stack
+    Chuck_VM_Stack * reg; // operand stack
 
     // ref to base stack - if this is the root, then base is mem
     Chuck_VM_Stack * base_ref;
@@ -221,11 +229,16 @@ public: // machine components
     Chuck_VM_Shred * parent;
     // children shreds
     std::map<t_CKUINT, Chuck_VM_Shred *> children;
+
+    // child stack size hints | 1.5.1.4
+    t_CKINT memStackSize;
+    t_CKINT regStackSize;
+
     // program counter
     t_CKUINT pc;
-
     // time
     t_CKTIME now;
+    // when started, in chuck time, relative to start of VM
     t_CKTIME start;
     // vm reference
     Chuck_VM * vm_ref;
@@ -684,6 +697,8 @@ struct Chuck_Msg
     Chuck_VM_Code * code;
     // VM shred pointer, as applicable
     Chuck_VM_Shred * shred;
+    // parent shred, as applicable
+    Chuck_VM_Shred * parent;
     // time, as applicable
     t_CKTIME when;
     // pointer to status struct, as applicable

--- a/src/core/ugen_xxx.cpp
+++ b/src/core/ugen_xxx.cpp
@@ -1606,7 +1606,8 @@ CK_DLL_CTOR( foogen_ctor )
 
         data->shred = new Chuck_VM_Shred;
         data->shred->vm_ref = SHRED->vm_ref;
-        data->shred->initialize(code);
+        // initialize with stack size hints | 1.5.1.4
+        data->shred->initialize( code, SHRED->childGetMemSize(), SHRED->childGetRegSize() );
     }
     else
     {


### PR DESCRIPTION
test program (not part of the PR)
```
// test many simultaneous shreds
// each sporked shred is relatively lightweight
// NOTE there is a sine wave 'foo' signal; to hear when
//   real-time audio breaks down either due to the sheer # of
//   shreds running or from adding a new shred when there is
//   a lot of shreds in the system; it is possible that audio
//   clicks when adding shreds (e.g., beyond 10000) but that
//   audio is actually smooth once no more shreds are added
//   (e.g., when N is reached); this is also a function of the
//   rate that the shreds are waking up and doing something,
//   controlled in the `randomizer()` function
// NOTE by default, each shred allocates a 65K 
int N;

// check arguments
if( me.args() ) me.arg(0) => Std.atoi => N;
// default value
if( N <= 0 ) 25000 => N;

// how many to spork at a time
N / 250 => int INC;
// make sure at least 1
if( INC == 0 ) 1 => INC;

// let's keep this one at constant freq
// for different values of N, does this sound stable?
SinOsc foo => dac;
440 => foo.freq;
.1 => foo.gain;

// make another one to randomizer
SinOsc bar => dac;
.1 => bar.gain;

// set child stack sizes to be much smaller
// so we can spork A LOT of shreds with less memory
me.childMemSize( 1024 );
me.childRegSize( 256 );

// gonna be sporking a lot of shreds and keep them running
<<< "sporking", N, "shreds..." >>>;

int sporked;
while( sporked < N )
{
    // spork away
    repeat( INC ) spork ~ randomizer( bar );
    // increment
    INC +=> sporked;
    // print
    <<< "sporked", sporked, "shreds so far..." >>>;
    // wait
    50::ms => now;
}

// a long time
eon => now;

// entry point for shreds
fun void randomizer( Osc oscil )
{
    while( true )
    {
        // random frequency
        Math.random2f(100,4000) => oscil.freq;
        // wait some randomized amount
        20*Math.random2f(.9,1.1)::second => now;
    }
}
```