### PR TITLE
Adding array support in Type

### DIFF
--- a/src/core/chuck_absyn.cpp
+++ b/src/core/chuck_absyn.cpp
@@ -584,10 +584,10 @@ a_Exp new_exp_from_array_lit( a_Array_Sub exp_list, uint32_t lineNum, uint32_t p
     a->s_meta = ae_meta_value;
     a->primary.s_type = ae_primary_array;
     a->primary.array = exp_list;
+    a->primary.array->self = a; // 1.5.1.9 (ge & nshaheed) added
     a->line = lineNum; a->where = posNum;
     a->primary.line = lineNum; a->primary.where = posNum;
     a->primary.self = a;
-
     return a;
 }
 

--- a/src/core/chuck_emit.cpp
+++ b/src/core/chuck_emit.cpp
@@ -2568,7 +2568,7 @@ t_CKBOOL emit_engine_emit_op( Chuck_Emitter * emit, ae_Operator op, a_Exp lhs, a
         {
             // check size (1.3.1.0: changed to getkindof)
             t_CKUINT kind = getkindof( emit->env, t_left->array_type );
-            // but if array depth > 1, we are actulaly dealing with pointers, hence back to INT
+            // but if array depth > 1, we are actually dealing with pointers, hence back to INT
             if( t_left->array_depth > 1 ) kind = kindof_INT;
             emit->append( instr = new Chuck_Instr_Array_Append( kind ) );
             instr->set_linepos( lhs->line );

--- a/src/core/chuck_instr.cpp
+++ b/src/core/chuck_instr.cpp
@@ -4395,6 +4395,48 @@ Chuck_Object * instantiate_and_initialize_object( Chuck_Type * type, Chuck_VM_Sh
             // initialize shred | 1.5.1.5 (ge) added, along with child mem and reg stack size hints
             if( !newShred->initialize( NULL, mems, regs ) ) goto error;
         }
+        else if (isa(type, vm->env()->ckt_array))
+        {
+            // 1.5.1.9 (nshaheed) added
+            // TODO - add reference counting?
+            // TODO - deal with depth
+
+            Chuck_Type* array_type = type->array_type;
+            if (isa(array_type, vm->env()->ckt_int))
+            {
+                object = new Chuck_ArrayInt(false, 0);
+            }
+            else if (isa(array_type, vm->env()->ckt_float)
+                || isa(array_type, vm->env()->ckt_dur)
+                || isa(array_type, vm->env()->ckt_time)
+                || isa(array_type, vm->env()->ckt_dur))
+            {
+                object = new Chuck_ArrayFloat(0);
+            }
+            else if (isa(array_type, vm->env()->ckt_polar)
+                || isa(array_type, vm->env()->ckt_polar)
+                || isa(array_type, vm->env()->ckt_complex))
+            {
+                object = new Chuck_Array16(0);
+            }
+            else if (isa(array_type, vm->env()->ckt_vec3))
+            {
+                object = new Chuck_Array24(0);
+            }
+            else if (isa(array_type, vm->env()->ckt_vec4))
+            {
+                object = new Chuck_Array32(0);
+            }
+            else if (isa(array_type, vm->env()->ckt_object))
+            {
+                object = new Chuck_ArrayInt(true, 0);
+            }
+            else // uh oh...
+            {
+                goto error;
+            }
+
+        }
         // 1.5.0.0 (ge) added -- here my feeble brain starts leaking out of my eyeballs
         else if( isa( type, vm->env()->ckt_class ) ) object = new Chuck_Type( vm->env(), te_class, type->base_name, type, type->size );
         // TODO: is this ok?

--- a/src/core/chuck_lang.cpp
+++ b/src/core/chuck_lang.cpp
@@ -3492,7 +3492,8 @@ CK_DLL_MFUN( type_isObject )
 CK_DLL_MFUN( type_isArray )
 {
     Chuck_Type * type = (Chuck_Type *)SELF;
-    RETURN->v_int = type->array_depth > 0;
+    // test for arrayhood -- either array depth > 0 or type could be "@array" | 1.5.1.9
+    RETURN->v_int = type->array_depth > 0 || isa(type, type->env()->ckt_array);
 }
 
 CK_DLL_MFUN( type_arrayDims )
@@ -3525,7 +3526,13 @@ CK_DLL_SFUN( type_typeOf_obj )
         RETURN->v_object = NULL;
         return;
     }
+
     // get type
+    // NOTE: Chuck_Object->type_ref may have different semantics for typeOf() and Type.of()
+    // [1.0] @=> float array[];
+    // <<< array.typeOf().isArray() >>>;
+    // <<< Type.of(array).isArray() >>>;
+    // TODO: do these need to be unified?
     RETURN->v_object = obj->type_ref;
 }
 

--- a/src/test/01-Basic/235-type-array.ck
+++ b/src/test/01-Basic/235-type-array.ck
@@ -1,7 +1,17 @@
 [1] @=> int arr_prim[];
 
-<<< Type.of(arr_prim).name() >>>;
-<<< Type.of(arr_prim).isArray() >>>;
+if(!Type.of(arr_prim).isArray()) me.exit();
 
-<<< Type.find("int[]").name() >>>;
-<<< Type.find("int[]").isArray() >>>;
+vec2 arr_vec2[0];
+if(!Type.of(arr_vec2).isArray()) me.exit();
+
+SinOsc arr_sin[0];
+if(!Type.of(arr_sin).isArray()) me.exit();
+
+
+if(!Type.find("int[]").isArray()) me.exit();
+if(!Type.find("vec2[][][][]").isArray()) me.exit();
+if(!Type.find("SinOsc[][]").isArray()) me.exit();
+if(Type.find("float").isArray()) me.exit;
+
+<<< "success" >>>;

--- a/src/test/01-Basic/235-type-array.ck
+++ b/src/test/01-Basic/235-type-array.ck
@@ -1,0 +1,7 @@
+[1] @=> int arr_prim[];
+
+<<< Type.of(arr_prim).name() >>>;
+<<< Type.of(arr_prim).isArray() >>>;
+
+<<< Type.find("int[]").name() >>>;
+<<< Type.find("int[]").isArray() >>>;


### PR DESCRIPTION
This is my first-draft attempt at adding array support in `Type`. Currently there's some inconsistency in behavior. The following code:

```
[1] @=> int arr_prim[];

<<< Type.of(arr_prim).name() >>>;
<<< Type.of(arr_prim).isArray() >>>;

<<< Type.find("int[]").name() >>>;
<<< Type.find("int[]").isArray() >>>;
```

Prints out
```
"@array" :(string)
0 :(int)
"int[]" :(string)
1 :(int)
```

So, `isArray()` is working for `find`, but not `of`.