### PR TITLE
change bool to t_CKBOOL to avoid an implicit conversion

### DIFF
--- a/src/core/chuck_dl.cpp
+++ b/src/core/chuck_dl.cpp
@@ -1515,7 +1515,7 @@ Chuck_Object * do_ck_create( Chuck_VM_Shred * shred, Chuck_VM * vm, Chuck_DL_Api
     {
         // 1.5.1.9 (nshaheed) added
         t_CKINT index = 0;
-        bool is_object = isa(type->array_type, vm->env()->ckt_object);
+        t_CKBOOL is_object = isa(type->array_type, vm->env()->ckt_object);
         // get array depth
         t_CKUINT depth = type->array_depth;
         // create capacity


### PR DESCRIPTION
Compiling the latest ChucK core for Chunreal on Windows 11 results in: 
Error C4800 Implicit conversion from 'unsigned __int64' to bool. Possible information loss
chuck_dl.cpp 1518	

Changed `bool is_object` to `t_CKBOOL is_object` to avoid an implicit conversion.
