### PR TITLE
Introducing WebChugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@
 /src/Release
 /src/Debug
 
+/src/host-web/webchuck/js/webchuck.js
+/src/host-web/webchuck/js/webchuck.wasm
+
 .DS_Store
 project.xcworkspace
 xcuserdata

--- a/src/core/chuck.cpp
+++ b/src/core/chuck.cpp
@@ -725,12 +725,20 @@ t_CKBOOL ChucK::initChugins()
         // push indent level
         // EM_pushlog();
         // load external libs | 1.5.0.4 (ge) enabled recursive search
-        // tf 2023: changed this for webchuck
-        if( !compiler()->load_external_modules( ".chug.js", dl_search_path, named_dls, TRUE ) )
+
+        #ifdef __EMSCRIPTEN__
+        if( !compiler()->load_external_modules( ".chug.wasm", dl_search_path, named_dls, TRUE ) )
         {
             // clean up
             goto error;
         }
+        #else
+        if( !compiler()->load_external_modules( ".chug", dl_search_path, named_dls, TRUE ) )
+        {
+            // clean up
+            goto error;
+        }
+        #endif
         // pop log
         // EM_poplog();
 

--- a/src/core/chuck.cpp
+++ b/src/core/chuck.cpp
@@ -725,7 +725,8 @@ t_CKBOOL ChucK::initChugins()
         // push indent level
         // EM_pushlog();
         // load external libs | 1.5.0.4 (ge) enabled recursive search
-        if( !compiler()->load_external_modules( ".chug", dl_search_path, named_dls, TRUE ) )
+        // tf 2023: changed this for webchuck
+        if( !compiler()->load_external_modules( ".chug.js", dl_search_path, named_dls, TRUE ) )
         {
             // clean up
             goto error;

--- a/src/core/chuck.cpp
+++ b/src/core/chuck.cpp
@@ -724,21 +724,20 @@ t_CKBOOL ChucK::initChugins()
         EM_log( CK_LOG_SYSTEM, "loading chugins..." );
         // push indent level
         // EM_pushlog();
-        // load external libs | 1.5.0.4 (ge) enabled recursive search
 
-        #ifdef __EMSCRIPTEN__
-        if( !compiler()->load_external_modules( ".chug.wasm", dl_search_path, named_dls, TRUE ) )
+        // chugin extension
+        std::string extension = ".chug";
+#ifdef __EMSCRIPTEN__
+        // webchugins have extension ".chug.wasm" | 1.5.2.0 (terryzfeng) added
+        extension = "chug.wasm";
+#endif
+        // load external libs | 1.5.0.4 (ge) enabled recursive search
+        if( !compiler()->load_external_modules( extension.c_str(), dl_search_path, named_dls, TRUE ) )
         {
             // clean up
             goto error;
         }
-        #else
-        if( !compiler()->load_external_modules( ".chug", dl_search_path, named_dls, TRUE ) )
-        {
-            // clean up
-            goto error;
-        }
-        #endif
+
         // pop log
         // EM_poplog();
 
@@ -859,8 +858,16 @@ void ChucK::probeChugins()
     EM_log( CK_LOG_SYSTEM, "probing chugins (.chug)..." );
     // push indent level
     // EM_pushlog();
+
+    // chugin extension
+    std::string extension = ".chug";
+#ifdef __EMSCRIPTEN__
+    // webchugins have extension ".chug.wasm" | 1.5.2.0 (terryzfeng) added
+    extension = "chug.wasm";
+#endif
+
     // load external libs
-    if( !Chuck_Compiler::probe_external_modules( ".chug", dl_search_path, named_dls, TRUE, ck_libs_to_preload ) )
+    if( !Chuck_Compiler::probe_external_modules( extension.c_str(), dl_search_path, named_dls, TRUE, ck_libs_to_preload ) )
     {
         // warning
         EM_log( CK_LOG_SYSTEM, "error probing chugins..." );

--- a/src/core/chuck_compile.cpp
+++ b/src/core/chuck_compile.cpp
@@ -1077,6 +1077,9 @@ t_CKBOOL load_external_modules_in_directory( Chuck_Compiler * compiler,
     // push
     EM_pushlog();
 
+    // tf 2023 webchugins
+    printf("webchugin load: %s, %s\n", directory, extension);
+
     // scan
     t_CKBOOL retval = scan_external_modules_in_directory( directory, extension, recursiveSearch, chugins2load, dirs2search, ckfiles2load );
     if( !retval )

--- a/src/core/chuck_compile.cpp
+++ b/src/core/chuck_compile.cpp
@@ -1077,9 +1077,6 @@ t_CKBOOL load_external_modules_in_directory( Chuck_Compiler * compiler,
     // push
     EM_pushlog();
 
-    // tf 2023 webchugins
-    printf("webchugin load: %s, %s\n", directory, extension);
-
     // scan
     t_CKBOOL retval = scan_external_modules_in_directory( directory, extension, recursiveSearch, chugins2load, dirs2search, ckfiles2load );
     if( !retval )

--- a/src/host-web/chuck_emscripten.cpp
+++ b/src/host-web/chuck_emscripten.cpp
@@ -713,7 +713,7 @@ extern "C"
             std::list< std::string > chugin_search;
             // chugin_search.push_back( chuck_global_data_dir + "/Chugins" );
             // chugin_search.push_back( chuck_global_data_dir + "/ChuGins" );
-            chugin_search.push_back( chuck_global_data_dir + "/chugins" );
+            chugin_search.push_back( chuck_global_data_dir + "chugins" );
             chuck->setParam( CHUCK_PARAM_USER_CHUGIN_DIRECTORIES, chugin_search );
  
             // default real-time audio is true | chuck-1.4.2.1 (ge) added

--- a/src/host-web/chuck_emscripten.cpp
+++ b/src/host-web/chuck_emscripten.cpp
@@ -711,11 +711,11 @@ extern "C"
             chuck->setParam( CHUCK_PARAM_WORKING_DIRECTORY, chuck_global_data_dir );
             // directories to search for chugins and auto-run ck files
             std::list< std::string > chugin_search;
-            chugin_search.push_back( chuck_global_data_dir + "/Chugins" );
-            chugin_search.push_back( chuck_global_data_dir + "/ChuGins" );
+            // chugin_search.push_back( chuck_global_data_dir + "/Chugins" );
+            // chugin_search.push_back( chuck_global_data_dir + "/ChuGins" );
             chugin_search.push_back( chuck_global_data_dir + "/chugins" );
             chuck->setParam( CHUCK_PARAM_USER_CHUGIN_DIRECTORIES, chugin_search );
-
+ 
             // default real-time audio is true | chuck-1.4.2.1 (ge) added
             // set hint, so internally can advise things like async data writes etc.
             chuck->setParam( CHUCK_PARAM_IS_REALTIME_AUDIO_HINT, (t_CKINT)TRUE );

--- a/src/host-web/chucknode-postjs.js
+++ b/src/host-web/chucknode-postjs.js
@@ -506,6 +506,8 @@ class ChuckNode extends AudioWorkletProcessor
                 {
                     return function()
                     {
+                        Module["FS_createPath"]("/", "chugins", true, true);
+
                         for( var i = 0; i < filesToPreload.length; i++ )
                         {
                             Module["FS_createPreloadedFile"]( "/", 
@@ -534,12 +536,12 @@ class ChuckNode extends AudioWorkletProcessor
                 self._heapOutputBuffer = new HeapAudioBuffer(Module, RENDER_QUANTUM_FRAMES,
                     self.outChannels, MAX_CHANNEL_COUNT);
 
+                // log
+                setLogLevel( 3 );
+
                 // initialize chuck instance
                 // FYI this invokes `new ChucK()` + instance initialization on the C++ side
                 initChuckInstance( self.myID, self.srate, self.inChannels, self.outChannels );
-
-                // log
-                // setLogLevel( 10 );
 
                 // flag
                 self.haveInit = true;

--- a/src/host-web/chucknode-postjs.js
+++ b/src/host-web/chucknode-postjs.js
@@ -367,7 +367,7 @@ var initGlobals = function( Module )
     clearGlobals = Module.cwrap( 'clearGlobals', 'number', ['number'] );
     cleanupChuckInstance = Module.cwrap( 'cleanupChuckInstance', 'number', ['number'] );
     cleanRegisteredChucks = Module.cwrap( 'cleanRegisteredChucks', null );
-
+ 
     // running code 
     runChuckCode = Module.cwrap( 'runChuckCode', 'number', ['number', 'string'] );
     runChuckCodeWithReplacementDac = Module.cwrap( 'runChuckCodeWithReplacementDac', 'number', ['number', 'string', 'string'] );
@@ -454,25 +454,30 @@ class ChuckNode extends AudioWorkletProcessor
     {
         super();
         
+        // Extract constructor options
         this.srate = options.processorOptions.srate;
         this.inChannels = options.outputChannelCount[0];
         this.outChannels = options.outputChannelCount[0];
-        
         this.myID = options.processorOptions.chuckID;
         
         chucks[this.myID] = this;
         
-        // do this in response to an incoming message
+        // Set up a message handler to respond to incoming messages
         this.port.onmessage = this.handle_message.bind(this);
                     
+        // Initialize properties for this ChuckNode instance
         this.myPointers = {}
         this.myActiveShreds = [];
         this.haveInit = false;
 
+        // Initialize the Chuck AudioWorkletProcessor
         this.init( options.processorOptions.preloadedFiles, 
                    options.processorOptions.wasm );
     }
     
+    /**
+     * Initialize the Chuck as an AudioWorkletProcessor.
+     */
     init( preloadedFiles, wasm )
     {
         if( !globalInit )
@@ -483,7 +488,6 @@ class ChuckNode extends AudioWorkletProcessor
                     {
                         return function( text )
                         {
-                            console.log( text );
                             self.port.postMessage( { type: "console print", message: text } );
                         }
                     })( this ),
@@ -491,7 +495,6 @@ class ChuckNode extends AudioWorkletProcessor
                     {
                         return function( text )
                         {
-                            console.error( text );
                             self.port.postMessage( { type: "console print", message: text } );
                         }
                     })( this ),
@@ -506,8 +509,10 @@ class ChuckNode extends AudioWorkletProcessor
                 {
                     return function()
                     {
+                        // Create a directory for chugins
                         Module["FS_createPath"]("/", "chugins", true, true);
 
+                        // Preload files into the file system
                         for( var i = 0; i < filesToPreload.length; i++ )
                         {
                             Module["FS_createPreloadedFile"]( "/", 
@@ -537,7 +542,7 @@ class ChuckNode extends AudioWorkletProcessor
                     self.outChannels, MAX_CHANNEL_COUNT);
 
                 // log
-                setLogLevel( 3 );
+                //setLogLevel( 3 );
 
                 // initialize chuck instance
                 // FYI this invokes `new ChucK()` + instance initialization on the C++ side
@@ -551,7 +556,7 @@ class ChuckNode extends AudioWorkletProcessor
             }
         })( this ) );   
     }
-    
+
     handleNewShredID( newShredID, shredCallback )
     {
         if( newShredID > 0 )
@@ -644,7 +649,7 @@ class ChuckNode extends AudioWorkletProcessor
         switch( event.data.type )
         {
         // ================== Filesystem ===================== //
-            case 'loadFile':
+            case 'createFile':
                 this.Module.FS_createDataFile( '/' + event.data.directory, 
                     event.data.filename, event.data.data, true, true, true );
                 break;

--- a/src/makefile
+++ b/src/makefile
@@ -45,12 +45,14 @@ EMSCRIPTENSRCS=host-web/chuck_emscripten.cpp \
     core/util_raw.c core/util_string.cpp core/util_xforms.c \
     core/chuck_yacc.c core/util_sndfile.c
 
+EMSCRIPTEN_POSTJS=host-web/chucknode-postjs.js
+
 # make targets
 .PHONY: emscripten web
 emscripten: host-web/webchuck/js/webchuck.js
 web: host-web/webchuck/js/webchuck.js
 # recipe
-host-web/webchuck/js/webchuck.js: $(EMSCRIPTENSRCS)
+host-web/webchuck/js/webchuck.js: $(EMSCRIPTENSRCS) $(EMSCRIPTEN_POSTJS)
 	emcc -O3 -s DISABLE_EXCEPTION_CATCHING=0 -Icore \
 	-D__DISABLE_MIDI__ -D__DISABLE_WATCHDOG__ -D__DISABLE_NETWORK__ \
 	-D__DISABLE_OTF_SERVER__ -D__ALTER_HID__ -D__DISABLE_HID__ \
@@ -61,7 +63,7 @@ host-web/webchuck/js/webchuck.js: $(EMSCRIPTENSRCS)
 	-s EXPORTED_RUNTIME_METHODS='["ccall", "cwrap", "getValue", "setValue", "addFunction", "removeFunction", "UTF8ToString", "stringToUTF8"]' \
 	-s LINKABLE=1 -s MODULARIZE=1 -s 'EXPORT_NAME="ChucK"' \
 	-s ALLOW_MEMORY_GROWTH=1 \
-	-s --extern-post-js host-web/chucknode-postjs.js \
+	-s --extern-post-js $(EMSCRIPTEN_POSTJS) \
 	-s RESERVED_FUNCTION_POINTERS=50 -s FORCE_FILESYSTEM=1
 
 

--- a/src/makefile
+++ b/src/makefile
@@ -53,18 +53,19 @@ emscripten: host-web/webchuck/js/webchuck.js
 web: host-web/webchuck/js/webchuck.js
 # recipe
 host-web/webchuck/js/webchuck.js: $(EMSCRIPTENSRCS) $(EMSCRIPTEN_POSTJS)
-	emcc -O3 -s DISABLE_EXCEPTION_CATCHING=0 -Icore \
+	emcc -O3 -s MAIN_MODULE=1 -s DISABLE_EXCEPTION_CATCHING=0 -Icore \
 	-D__DISABLE_MIDI__ -D__DISABLE_WATCHDOG__ -D__DISABLE_NETWORK__ \
 	-D__DISABLE_OTF_SERVER__ -D__ALTER_HID__ -D__DISABLE_HID__ \
 	-D__DISABLE_SERIAL__ -D__DISABLE_ASYNCH_IO__ -D__DISABLE_THREADS__ \
 	-D__DISABLE_KBHIT__ -D__DISABLE_PROMPTER__ -D__DISABLE_SHELL__ \
 	-D__CHUCK_USE_PLANAR_BUFFERS__ -D__OLDSCHOOL_RANDOM__ \
 	-Wformat=0 $(EMSCRIPTENSRCS) -o host-web/webchuck/js/webchuck.js \
+	-s EXPORTED_FUNCTIONS="['_malloc']" \
 	-s EXPORTED_RUNTIME_METHODS='["ccall", "cwrap", "getValue", "setValue", "addFunction", "removeFunction", "UTF8ToString", "stringToUTF8"]' \
-	-s LINKABLE=1 -s MODULARIZE=1 -s 'EXPORT_NAME="ChucK"' \
-	-s ALLOW_MEMORY_GROWTH=1 \
+	-s MODULARIZE=1 -s ALLOW_MEMORY_GROWTH=1 \
+	-s RESERVED_FUNCTION_POINTERS=50 -s FORCE_FILESYSTEM=1 \
 	-s --extern-post-js $(EMSCRIPTEN_POSTJS) \
-	-s RESERVED_FUNCTION_POINTERS=50 -s FORCE_FILESYSTEM=1
+	-s 'EXPORT_NAME="ChucK"' \
 
 
 ################################ PLATFORMS ####################################


### PR DESCRIPTION
Updates Chugin probing to open webchugins WASM
- Webchuck creates a `/chugins` folder
- Look for `chug.wasm` in `/chugins`
Clean WebChucK Printing
- Only print via output messages to webchuck
Updated Makefile and flags to be compatible with Emscripten 3.1.48
- `MainModule=1`
- `ExportedFunctions=[malloc]`
