### PR TITLE
chugin ck_info() support added to host

### DIFF
--- a/VERSIONS
+++ b/VERSIONS
@@ -2,6 +2,36 @@
 ChucK VERSIONS log
 ------------------
 
+1.5.2.1 (December 2023) patch release
+=======
+- (added) chugins can now implement a "info query function" to provide 
+    chugin-specific infomation to be accessible from host, including:
+    * chugin author(s)
+    * chugin version (not to be confused with compatbility version)
+    * chugin description
+    * chugin URL
+for example, in the chugin source:
+```
+// chugin info func
+CK_DLL_INFO( MyChugin )
+{
+    // set module name
+    QUERY->setname(QUERY, "FooBar");
+
+    // set info
+    QUERY->setinfo( QUERY, CHUGIN_INFO_AUTHORS, "Ana B. Croft" );
+    QUERY->setinfo( QUERY, CHUGIN_INFO_CHUGIN_VERSION, "v3.6.1" );
+    QUERY->setinfo( QUERY, CHUGIN_INFO_DESCRIPTION, "what does it do?" );
+    QUERY->setinfo( QUERY, CHUGIN_INFO_URL, "https://foo.com/FooBar" );
+    QUERY->setinfo( QUERY, CHUGIN_INFO_EMAIL, "ana@foo.com" );
+}
+```
+- (updated) revert chugin/host compatibility policy
+    chugin major version must == host major version
+    chugin minor version must <= host minor version
+  (previously in 1.5.2.0) chugin AND host API version must match
+
+
 1.5.2.0 (November 2023) "Better Late Than Never...constructors"
 =======
 - (added) class constructors

--- a/VERSIONS
+++ b/VERSIONS
@@ -4,20 +4,21 @@ ChucK VERSIONS log
 
 1.5.2.1 (December 2023) patch release
 =======
+- (added) ChuGL (alpha) is now part of the standard chuck distribution
+    https://chuck.stanford.edu/chugl/
+=======
 - (added) chugins can now implement a "info query function" to provide 
     chugin-specific infomation to be accessible from host, including:
     * chugin author(s)
     * chugin version (not to be confused with compatbility version)
     * chugin description
-    * chugin URL
+    * (optional) chugin URL
+    * (optional) contact email
 for example, in the chugin source:
 ```
 // chugin info func
 CK_DLL_INFO( MyChugin )
 {
-    // set module name
-    QUERY->setname(QUERY, "FooBar");
-
     // set info
     QUERY->setinfo( QUERY, CHUGIN_INFO_AUTHORS, "Ana B. Croft" );
     QUERY->setinfo( QUERY, CHUGIN_INFO_CHUGIN_VERSION, "v3.6.1" );

--- a/src/core/chuck.cpp
+++ b/src/core/chuck.cpp
@@ -614,7 +614,7 @@ t_CKBOOL ChucK::initCompiler()
     if( (cstr_cwd = getcwd(NULL, 0)) == NULL )
     {
         // uh...
-        EM_log( CK_LOG_SEVERE, "error: unable to determine current working directory!" );
+        EM_log( CK_LOG_HERALD, "error: unable to determine current working directory!" );
     }
     else
     {
@@ -713,7 +713,7 @@ t_CKBOOL ChucK::initChugins()
 
         EM_pushlog();
         // print host version
-        EM_log( CK_LOG_SEVERE, TC::green("host API version: %d.%d", true).c_str(), CK_DLL_VERSION_MAJOR, CK_DLL_VERSION_MINOR );
+        EM_log( CK_LOG_HERALD, TC::green("host API version: %d.%d", true).c_str(), CK_DLL_VERSION_MAJOR, CK_DLL_VERSION_MINOR );
         EM_poplog();
 
         //---------------------------------------------------------------------
@@ -758,7 +758,7 @@ t_CKBOOL ChucK::initChugins()
             std::string filename = *j;
 
             // log
-            EM_log( CK_LOG_SEVERE, "preloading '%s'...", filename.c_str() );
+            EM_log( CK_LOG_HERALD, "preloading '%s'...", filename.c_str() );
             // push indent
             EM_pushlog();
 
@@ -829,16 +829,20 @@ void ChucK::probeChugins()
 {
     // ck files to pre load
     std::list<std::string> ck_libs_to_preload;
+    // host verison
+    ostringstream ostr; ostr << CK_DLL_VERSION_MAJOR << "." << CK_DLL_VERSION_MINOR;
 
     // print whether chugins enabled
     EM_log( CK_LOG_SYSTEM, "chugin system: %s", getParamInt( CHUCK_PARAM_CHUGIN_ENABLE ) ? "ON" : "OFF" );
     // print host version
-    EM_log( CK_LOG_SYSTEM, TC::green("host API version: %d.%d", true).c_str(), CK_DLL_VERSION_MAJOR, CK_DLL_VERSION_MINOR );
+    EM_log( CK_LOG_SYSTEM, "chugin host API version: %s", TC::green(ostr.str(),true).c_str() );
     // push
     EM_pushlog();
     // print version compatbility information
     EM_log( CK_LOG_SYSTEM, "chugin major version must == host major version" );
     EM_log( CK_LOG_SYSTEM, "chugin minor version must <= host minor version" );
+    // print chuck language version
+    EM_log( CK_LOG_SYSTEM, "language version: %s", TC::green(CHUCK_VERSION_STRING,true).c_str() );
     // pop
     EM_poplog();
 

--- a/src/core/chuck.cpp
+++ b/src/core/chuck.cpp
@@ -836,11 +836,9 @@ void ChucK::probeChugins()
     EM_log( CK_LOG_SYSTEM, TC::green("host API version: %d.%d", true).c_str(), CK_DLL_VERSION_MAJOR, CK_DLL_VERSION_MINOR );
     // push
     EM_pushlog();
-    // print host version
-    EM_log( CK_LOG_SYSTEM, "note: chugin API version must match that of host" ); // 1.5.2.0
-    // previously:
-    // EM_log( CK_LOG_SYSTEM, "chugin major version must == host major version" );
-    // EM_log( CK_LOG_SYSTEM, "chugin minor version must <= host major version" );
+    // print version compatbility information
+    EM_log( CK_LOG_SYSTEM, "chugin major version must == host major version" );
+    EM_log( CK_LOG_SYSTEM, "chugin minor version must <= host minor version" );
     // pop
     EM_poplog();
 

--- a/src/core/chuck_compile.cpp
+++ b/src/core/chuck_compile.cpp
@@ -697,7 +697,7 @@ t_CKBOOL load_module( Chuck_Compiler * compiler, Chuck_Env * env, f_ck_query que
 t_CKBOOL load_internal_modules( Chuck_Compiler * compiler )
 {
     // log
-    EM_log( CK_LOG_SEVERE, "loading built-in modules..." );
+    EM_log( CK_LOG_HERALD, "loading built-in modules..." );
     // push indent level
     EM_pushlog();
 
@@ -717,31 +717,31 @@ t_CKBOOL load_internal_modules( Chuck_Compiler * compiler )
 #endif // __DISABLE_MIDI__
 
     // load
-    EM_log( CK_LOG_SEVERE, "module 'math'" );
+    EM_log( CK_LOG_HERALD, "module 'math'" );
     if( !load_module( compiler, env, libmath_query, "math", "global" ) ) goto error;
-    EM_log( CK_LOG_SEVERE, "module 'osc'" );
+    EM_log( CK_LOG_HERALD, "module 'osc'" );
     load_module( compiler, env, osc_query, "osc", "global" );
-    EM_log( CK_LOG_SEVERE, "module 'ai'" );
+    EM_log( CK_LOG_HERALD, "module 'ai'" );
     if( !load_module( compiler, env, libai_query, "ai", "global" ) ) goto error;
-    EM_log( CK_LOG_SEVERE, "module 'extract'" );
+    EM_log( CK_LOG_HERALD, "module 'extract'" );
     load_module( compiler, env, extract_query, "extract", "global" );
-    EM_log( CK_LOG_SEVERE, "module 'filter'" );
+    EM_log( CK_LOG_HERALD, "module 'filter'" );
     load_module( compiler, env, filter_query, "filter", "global" );
-    EM_log( CK_LOG_SEVERE, "module 'STK'" );
+    EM_log( CK_LOG_HERALD, "module 'STK'" );
     load_module( compiler, env, stk_query, "stk", "global" );
-    EM_log( CK_LOG_SEVERE, "module 'xform'" );
+    EM_log( CK_LOG_HERALD, "module 'xform'" );
     load_module( compiler, env, xform_query, "xform", "global" );
-    EM_log( CK_LOG_SEVERE, "module 'xxx'" );
+    EM_log( CK_LOG_HERALD, "module 'xxx'" );
     load_module( compiler, env, xxx_query, "xxx", "global" );
-    EM_log( CK_LOG_SEVERE, "module 'std'" );
+    EM_log( CK_LOG_HERALD, "module 'std'" );
     if( !load_module( compiler, env, libstd_query, "std", "global" ) ) goto error;
 
     // load
-    EM_log( CK_LOG_SEVERE, "module 'machine'" );
+    EM_log( CK_LOG_HERALD, "module 'machine'" );
     if( !load_module( compiler, env, machine_query, "machine", "global" ) ) goto error;
 
     #ifndef __DISABLE_NETWORK__
-    EM_log( CK_LOG_SEVERE, "module 'opsc'" );
+    EM_log( CK_LOG_HERALD, "module 'opsc'" );
     if( !load_module( compiler, env, opensoundcontrol_query, "opsc", "global" ) ) goto error;
     #endif
 
@@ -749,16 +749,16 @@ t_CKBOOL load_internal_modules( Chuck_Compiler * compiler )
     // if( !load_module( compiler, env, net_query, "net", "global" ) ) goto error;
 
     #ifndef __DISABLE_HID__
-    EM_log( CK_LOG_SEVERE, "module 'HID'" );
+    EM_log( CK_LOG_HERALD, "module 'HID'" );
     if( !init_class_HID( env ) ) goto error;
     #endif
 
     #ifndef __DISABLE_SERIAL__
-    EM_log( CK_LOG_SEVERE, "module 'SerialIO'" );
+    EM_log( CK_LOG_HERALD, "module 'SerialIO'" );
     if( !init_class_serialio( env ) ) goto error;
     #endif
 
-    EM_log( CK_LOG_SEVERE, "module 'CKDoc'" );
+    EM_log( CK_LOG_HERALD, "module 'CKDoc'" );
     if( !load_module( compiler, env, ckdoc_query, "ckdoc", "global" ) ) goto error;
 
     // clear context
@@ -983,7 +983,7 @@ t_CKBOOL load_external_module_at_path( Chuck_Compiler * compiler,
 
     // log with no newline; print status next
     // NOTE this is more informative if the chugin crashes, we can see the name
-    EM_log_opts( CK_LOG_SEVERE, EM_LOG_NO_NEWLINE, "[%s] %s ", TC::magenta("chugin",true).c_str(), name );
+    EM_log_opts( CK_LOG_HERALD, EM_LOG_NO_NEWLINE, "[%s] %s ", TC::magenta("chugin",true).c_str(), name );
 
     Chuck_DLL * dll = new Chuck_DLL( compiler->carrier(), name );
     t_CKBOOL query_failed = FALSE;
@@ -997,10 +997,10 @@ t_CKBOOL load_external_module_at_path( Chuck_Compiler * compiler,
         if( !dll->compatible() )
         {
             // print
-            EM_log_opts( CK_LOG_SEVERE, EM_LOG_NO_PREFIX, "[%s] (API version: %d.%d)", TC::red("FAILED",true).c_str(), dll->versionMajor(), dll->versionMinor() );
+            EM_log_opts( CK_LOG_HERALD, EM_LOG_NO_PREFIX, "[%s] (API version: %d.%d)", TC::red("FAILED",true).c_str(), dll->versionMajor(), dll->versionMinor() );
             // push
             EM_pushlog();
-            EM_log( CK_LOG_SEVERE, "reason: %s", TC::orange(dll->last_error(),true).c_str() );
+            EM_log( CK_LOG_HERALD, "reason: %s", TC::orange(dll->last_error(),true).c_str() );
             EM_poplog();
             // go to error for cleanup
             goto error;
@@ -1012,15 +1012,15 @@ t_CKBOOL load_external_module_at_path( Chuck_Compiler * compiler,
         if( query_failed || !type_engine_add_dll2( env, dll, "global" ) )
         {
             // print
-            EM_log_opts( CK_LOG_SEVERE, EM_LOG_NO_PREFIX, "[%s] (API version: %d.%d)", TC::red("FAILED",true).c_str(), dll->versionMajor(), dll->versionMinor() );
+            EM_log_opts( CK_LOG_HERALD, EM_LOG_NO_PREFIX, "[%s] (API version: %d.%d)", TC::red("FAILED",true).c_str(), dll->versionMajor(), dll->versionMinor() );
             EM_pushlog();
             // if add_dll2 failed, an error should have already been output
             if( query_failed )
             {
                 // print reason
-                EM_log( CK_LOG_SEVERE, "reason: %s", TC::orange(dll->last_error(),true).c_str() );
+                EM_log( CK_LOG_HERALD, "reason: %s", TC::orange(dll->last_error(),true).c_str() );
             }
-            EM_log( CK_LOG_SEVERE, "%s '%s'...", TC::blue("skipping",true).c_str(), dl_path );
+            EM_log( CK_LOG_HERALD, "%s '%s'...", TC::blue("skipping",true).c_str(), dl_path );
             EM_poplog();
             // go to error for cleanup
             goto error;
@@ -1029,17 +1029,17 @@ t_CKBOOL load_external_module_at_path( Chuck_Compiler * compiler,
     else
     {
         // print
-        EM_log_opts( CK_LOG_SEVERE, EM_LOG_NO_PREFIX, "[%s]", TC::red("FAILED",true).c_str() );
+        EM_log_opts( CK_LOG_HERALD, EM_LOG_NO_PREFIX, "[%s]", TC::red("FAILED",true).c_str() );
         // more info
         EM_pushlog();
-        EM_log( CK_LOG_SEVERE, "reason: %s", TC::orange(dll->last_error(),true).c_str() );
+        EM_log( CK_LOG_HERALD, "reason: %s", TC::orange(dll->last_error(),true).c_str() );
         EM_poplog();
         // go to error for cleanup
         goto error;
     }
 
     // print
-    EM_log_opts( CK_LOG_SEVERE, EM_LOG_NO_PREFIX, "[%s]", TC::green("OK",true).c_str() );
+    EM_log_opts( CK_LOG_HERALD, EM_LOG_NO_PREFIX, "[%s]", TC::green("OK",true).c_str() );
     // add to compiler
     compiler->m_dlls.push_back(dll);
     // commit operator overloads | 1.5.1.5
@@ -1073,7 +1073,7 @@ t_CKBOOL load_external_modules_in_directory( Chuck_Compiler * compiler,
     vector<string> ckfiles2load;
 
     // print directory to examine
-    EM_log( CK_LOG_SEVERE, "searching '%s'", format_dir_name_for_display(directory).c_str() );
+    EM_log( CK_LOG_HERALD, "searching '%s'", format_dir_name_for_display(directory).c_str() );
     // push
     EM_pushlog();
 
@@ -1222,7 +1222,25 @@ t_CKBOOL probe_external_module_at_path( const char * name, const char * dl_path 
             EM_pushlog();
             EM_log( CK_LOG_SYSTEM, "reason: %s", TC::orange(dll->last_error(),true).c_str() );
             EM_poplog();
+        }
 
+        // print info if available
+        string name = dll->name();
+        string authors = dll->getinfo( CHUGIN_INFO_AUTHORS );
+        string version = dll->getinfo( CHUGIN_INFO_CHUGIN_VERSION );
+        string desc = dll->getinfo( CHUGIN_INFO_DESCRIPTION );
+        string url = dll->getinfo( CHUGIN_INFO_URL );
+        string email = dll->getinfo( CHUGIN_INFO_EMAIL );
+
+        if( authors.length() || version.length() || desc.length() || url.length() )
+        {
+            EM_pushlog();
+            if( version.length() ) EM_log( CK_LOG_SYSTEM, "version: %s", version.c_str() );
+            if( authors.length() ) EM_log( CK_LOG_SYSTEM, "author: %s", authors.c_str() );
+            if( desc.length() ) EM_log( CK_LOG_HERALD, "description: %s", desc.c_str() );
+            if( url.length() ) EM_log( CK_LOG_HERALD, "URL: %s", url.c_str() );
+            if( email.length() ) EM_log( CK_LOG_INFO, "email: %s", email.c_str() );
+            EM_poplog();
         }
     }
     else

--- a/src/core/chuck_dl.cpp
+++ b/src/core/chuck_dl.cpp
@@ -789,7 +789,7 @@ t_CKBOOL CK_DLL_CALL ck_end_class( Chuck_DL_Query * query )
         if( !type_engine_add_class_from_dl( query->env(), query->curr_class ) )
         {
             // should already be message
-            //EM_log(CK_LOG_SEVERE, "error importing class '%s' into type engine",
+            //EM_log(CK_LOG_HERALD, "error importing class '%s' into type engine",
             // query->curr_class->name.c_str());
 
             // pop
@@ -1243,6 +1243,18 @@ const char * Chuck_DLL::name() const
 const char * Chuck_DLL::filepath() const
 {
     return m_filename.c_str();
+}
+
+
+
+
+//-----------------------------------------------------------------------------
+// name: getinfo()
+// desc: get query info
+//-----------------------------------------------------------------------------
+string Chuck_DLL::getinfo( const string & key )
+{
+    return ck_getinfo( &m_query, key.c_str() );
 }
 
 

--- a/src/core/chuck_dl.cpp
+++ b/src/core/chuck_dl.cpp
@@ -103,6 +103,18 @@ t_CKUINT CK_DLL_CALL ck_builtin_declversion() { return CK_DLL_VERSION; }
 
 
 //-----------------------------------------------------------------------------
+// name: ck_builtin_info()
+// desc: builtin info func for internal modules
+//-----------------------------------------------------------------------------
+void CK_DLL_CALL ck_builtin_info( Chuck_DL_Query * query )
+{
+    // set nothing here
+}
+
+
+
+
+//-----------------------------------------------------------------------------
 // name: ck_setname()
 // desc: set the name of the module/chugin
 //-----------------------------------------------------------------------------
@@ -116,6 +128,7 @@ void CK_DLL_CALL ck_setname( Chuck_DL_Query * query, const char * name, t_CKBOOL
 // overload to get around function pointer business for f_setname
 void CK_DLL_CALL ck_setname( Chuck_DL_Query * query, const char * name )
 { ck_setname( query, name, TRUE ); }
+
 
 
 
@@ -933,7 +946,7 @@ Chuck_Carrier * Chuck_DL_Query::carrier() const { return m_carrier; }
 
 //-----------------------------------------------------------------------------
 // name: load()
-// desc: load dynamic link library
+// desc: load module (chugin/dll) from filename
 //-----------------------------------------------------------------------------
 t_CKBOOL Chuck_DLL::load( const char * filename, const char * func, t_CKBOOL lazy )
 {
@@ -964,12 +977,13 @@ t_CKBOOL Chuck_DLL::load( const char * filename, const char * func, t_CKBOOL laz
 
 //-----------------------------------------------------------------------------
 // name: load()
-// desc: load dynamic link library
+// desc: load module (internal) from query func
 //-----------------------------------------------------------------------------
 t_CKBOOL Chuck_DLL::load( f_ck_query query_func, t_CKBOOL lazy )
 {
     m_query_func = query_func;
     m_api_version_func = ck_builtin_declversion;
+    m_info_func = ck_builtin_info;
     m_done_query = FALSE;
     m_func = "ck_query";
 
@@ -1001,38 +1015,20 @@ t_CKBOOL Chuck_DLL::good() const
 //-----------------------------------------------------------------------------
 const Chuck_DL_Query * Chuck_DLL::query()
 {
-    if( !m_handle && !m_query_func )
-    {
-        m_last_error = "dynamic link library not loaded for query...";
-        return NULL;
-    }
-
     // return if there already
     if( m_done_query )
         return &m_query;
 
-    // get the address of the DL version function from the DLL
-    if( !m_api_version_func )
-        m_api_version_func = (f_ck_declversion)this->get_addr( CK_DECLVERSION_FUNC );
-    if( !m_api_version_func )
-        m_api_version_func = (f_ck_declversion)this->get_addr( (string("_")+CK_DECLVERSION_FUNC).c_str() );
-    if( !m_api_version_func )
-    {
-        m_last_error = string("no version function found in dll '") + m_filename + string("'");
+    // probe DLL, for version and info
+    if( !probe() )
         return NULL;
-    }
 
-    // check version
-    t_CKUINT dll_version = m_api_version_func();
-    // get major and minor version numbers
-    m_apiVersionMajor = CK_DLL_VERSION_GETMAJOR(dll_version);
-    m_apiVersionMinor = CK_DLL_VERSION_GETMINOR(dll_version);
     // is version ok
     t_CKBOOL version_ok = FALSE;
-    // major AND minor version must match | 1.5.2.0 (ge)
-    // (was: major version must be same; minor version must less than or equal)
+    // chugin major version must == host major version
+    // chugin minor version must <= host minor version
     if( m_apiVersionMajor == CK_DLL_VERSION_MAJOR &&
-        m_apiVersionMinor == CK_DLL_VERSION_MINOR)
+        m_apiVersionMinor <= CK_DLL_VERSION_MINOR)
         version_ok = TRUE;
 
     // if version not okay
@@ -1079,50 +1075,6 @@ const Chuck_DL_Query * Chuck_DLL::query()
                        + string("'");
         return NULL;
     }
-
-    // load the proto table
-    /* Chuck_DL_Proto * proto;
-    m_name2proto.clear();
-    for( t_CKUINT i = 0; i < m_query.dll_exports.size(); i++ )
-    {
-        proto = &m_query.dll_exports[i];
-        if( m_name2proto[proto->name] )
-        {
-            m_last_error = string("duplicate export name '") + proto->name
-                           + string("'");
-            return NULL;
-        }
-
-        // get the addr
-        if( !proto->addr )
-            proto->addr = (f_ck_func)this->get_addr( (char *)proto->name.c_str() );
-        if( !proto->addr )
-        {
-            m_last_error = string("no addr associated with export '") +
-                           proto->name + string("'");
-            return NULL;
-        }
-
-        // put in the lookup table
-        m_name2proto[proto->name] = proto;
-    }
-
-    // load the proto table
-    Chuck_UGen_Info * info;
-    m_name2ugen.clear();
-    for( t_CKUINT j = 0; j < m_query.ugen_exports.size(); j++ )
-    {
-        info = &m_query.ugen_exports[j];
-        if( m_name2ugen[info->name] )
-        {
-            m_last_error = string("duplicate export ugen name '") + info->name
-                           + string("'");
-            return NULL;
-        }
-
-        // put in the lookup table
-        m_name2ugen[info->name] = info;
-    }*/
 
     // set flag
     m_done_query = TRUE;
@@ -1194,6 +1146,19 @@ t_CKBOOL Chuck_DLL::probe()
     // get major and minor version numbers
     m_apiVersionMajor = CK_DLL_VERSION_GETMAJOR(dll_version);
     m_apiVersionMinor = CK_DLL_VERSION_GETMINOR(dll_version);
+
+    // get the address of the DL info function from the DLL
+    if( !m_info_func )
+        m_info_func = (f_ck_info)this->get_addr( CK_INFO_FUNC );
+    if( !m_info_func )
+        m_info_func = (f_ck_info)this->get_addr( (string("_")+CK_INFO_FUNC).c_str() );
+
+    // if info func found
+    if( m_info_func )
+    {
+        // query the module for info
+        m_info_func( &m_query );
+    }
 
     return TRUE;
 }

--- a/src/core/chuck_dl.h
+++ b/src/core/chuck_dl.h
@@ -241,6 +241,8 @@ typedef const Chuck_DL_Api * CK_DL_API;
 // macro for declaring version of ChucK DL a given DLL links to
 // example: CK_DLL_DECLVERSION
 #define CK_DLL_DECLVERSION CK_DLL_EXPORT(t_CKUINT) ck_version() { return CK_DLL_VERSION; }
+// macro for defining a DLL info func
+#define CK_DLL_INFO(name) CK_DLL_EXPORT(void) ck_info( Chuck_DL_Query * QUERY )
 // naming convention for static query functions
 #define CK_DLL_QUERY_STATIC_NAME(name) ck_##name##_query
 // macro for defining ChucK DLL export query-functions (static version)
@@ -314,7 +316,7 @@ typedef const Chuck_DL_Api * CK_DL_API;
 extern "C" {
 // query
 typedef t_CKUINT (CK_DLL_CALL * f_ck_declversion)();
-typedef const char * (CK_DLL_CALL * f_ck_info)( const char * key );
+typedef t_CKVOID (CK_DLL_CALL * f_ck_info)( Chuck_DL_Query * QUERY );
 typedef t_CKBOOL (CK_DLL_CALL * f_ck_query)( Chuck_DL_Query * QUERY );
 // object
 typedef Chuck_Object * (CK_DLL_CALL * f_alloc)( Chuck_VM * VM, Chuck_VM_Shred * SHRED, CK_DL_API API );
@@ -344,10 +346,12 @@ typedef void (CK_DLL_CALL * f_callback_on_instantiate)( Chuck_Object * OBJECT, C
 }
 
 
-// default name in DLL/ckx to look for
-#define CK_QUERY_FUNC        "ck_query"
-// default name in DLL/ckx to look for
-#define CK_DECLVERSION_FUNC  "ck_version"
+// default name in DLL/ckx to look for host/chugin compatibility version func
+#define CK_DECLVERSION_FUNC "ck_version"
+// default name in DLL/ckx to look for info func
+#define CK_INFO_FUNC        "ck_info"
+// default name in DLL/ckx to look for for query func
+#define CK_QUERY_FUNC       "ck_query"
 // bad object data offset
 #define CK_INVALID_OFFSET    0xffffffff
 
@@ -1102,10 +1106,11 @@ private:
 struct Chuck_DLL /* : public Chuck_VM_Object */
 {
 public:
-    // load dynamic ckx/dll from filename
+    // load module (chugin/dll) from filename
     t_CKBOOL load( const char * filename,
                    const char * func = CK_QUERY_FUNC,
                    t_CKBOOL lazy = FALSE );
+    // load module (internal) from query func
     t_CKBOOL load( f_ck_query query_func, t_CKBOOL lazy = FALSE );
     // get address in loaded ckx
     void * get_addr( const char * symbol );

--- a/src/core/chuck_dl.h
+++ b/src/core/chuck_dl.h
@@ -1138,6 +1138,10 @@ public:
     t_CKBOOL compatible();
 
 public:
+    // get info from query
+    std::string getinfo( const std::string & key );
+
+public:
     // constructor
     Chuck_DLL( Chuck_Carrier * carrier, const char * xid = NULL )
         : m_handle(NULL), m_id(xid ? xid : ""),

--- a/src/core/chuck_emit.cpp
+++ b/src/core/chuck_emit.cpp
@@ -119,7 +119,7 @@ void emit_engine_track_stmt_refs_cleanup( Chuck_Emitter * emit, Chuck_Instr_Stmt
 Chuck_Emitter * emit_engine_init( Chuck_Env * env )
 {
     // log
-    EM_log( CK_LOG_SEVERE, "initializing emitter..." );
+    EM_log( CK_LOG_HERALD, "initializing emitter..." );
 
     // TODO: ensure this in a better way?
     // whatever t_CKUINT is defined as, it must be the same size as a pointer

--- a/src/core/chuck_errmsg.h
+++ b/src/core/chuck_errmsg.h
@@ -47,7 +47,7 @@
 #define CK_LOG_DEBUG            6  // 1.5.0.5 was: CK_LOG_CONFIG
 #define CK_LOG_INFO             5
 #define CK_LOG_WARNING          4
-#define CK_LOG_SEVERE           3
+#define CK_LOG_HERALD           3
 #define CK_LOG_SYSTEM           2
 #define CK_LOG_CORE             1
 #define CK_LOG_NONE             0  // set this to log nothing

--- a/src/core/chuck_io.cpp
+++ b/src/core/chuck_io.cpp
@@ -105,7 +105,7 @@ t_CKBOOL init_class_io( Chuck_Env * env, Chuck_Type * type )
     std::string doc = "Base class for other IO classes such as FileIO, StdOut and StdErr. Besides IO.newline(), it’s unlikely you need to use this class directly.";
 
     // log
-    EM_log( CK_LOG_SEVERE, "class 'IO'" );
+    EM_log( CK_LOG_HERALD, "class 'IO'" );
     
     // init as base class
     // TODO: ctor/dtor?
@@ -315,7 +315,7 @@ t_CKBOOL init_class_fileio( Chuck_Env * env, Chuck_Type * type )
     Chuck_DL_Func * func = NULL;
 
     // log
-    EM_log( CK_LOG_SEVERE, "class 'FileIO'" );
+    EM_log( CK_LOG_HERALD, "class 'FileIO'" );
 
     // init as base class
     // TODO: ctor/dtor?
@@ -530,7 +530,7 @@ t_CKBOOL init_class_chout( Chuck_Env * env, Chuck_Type * type )
     Chuck_DL_Func * func = NULL;
 
     // log
-    EM_log( CK_LOG_SEVERE, "class 'chout'" );
+    EM_log( CK_LOG_HERALD, "class 'chout'" );
 
     // TODO: ctor/dtor?
     if( !type_engine_import_class_begin( env, type, env->global(), NULL, NULL, "Do not instantiate this class directly! Use 'chout' instead." ) )
@@ -620,7 +620,7 @@ t_CKBOOL init_class_cherr( Chuck_Env * env, Chuck_Type * type )
     Chuck_DL_Func * func = NULL;
 
     // log
-    EM_log( CK_LOG_SEVERE, "class 'cherr'" );
+    EM_log( CK_LOG_HERALD, "class 'cherr'" );
 
     // TODO: ctor/dtor?
     if( !type_engine_import_class_begin( env, type, env->global(), NULL, NULL, "Do not instantiate this class directly! Use 'cherr' instead." ) )
@@ -5823,7 +5823,7 @@ t_CKBOOL Chuck_IO_Serial::readAsync( t_CKUINT type, t_CKUINT num )
     }
     else
     {
-        EM_log(CK_LOG_SEVERE, "(SerialIO.readAsync): warning: request buffer overflow, dropping read");
+        EM_log(CK_LOG_HERALD, "(SerialIO.readAsync): warning: request buffer overflow, dropping read");
         return FALSE;
     }
 
@@ -5996,7 +5996,7 @@ t_CKBOOL Chuck_IO_Serial::get_buffer(t_CKINT timeout_ms)
         }
         else
         {
-            EM_log(CK_LOG_SEVERE, "(SerialIO::get_buffer): read() returned 0 bytes");
+            EM_log(CK_LOG_HERALD, "(SerialIO::get_buffer): read() returned 0 bytes");
         }
     }
     else
@@ -6386,7 +6386,7 @@ void Chuck_IO_Serial::read_cb()
         {
             if( m_asyncResponses.atMaximum() )
             {
-                EM_log(CK_LOG_SEVERE, "SerialIO.read_cb: error: response buffer overflow, dropping read");
+                EM_log(CK_LOG_HERALD, "SerialIO.read_cb: error: response buffer overflow, dropping read");
                 continue;
             }
 

--- a/src/core/chuck_lang.cpp
+++ b/src/core/chuck_lang.cpp
@@ -64,7 +64,7 @@ t_CKBOOL init_class_object( Chuck_Env * env, Chuck_Type * type )
     Chuck_Value * value = NULL;
 
     // log
-    EM_log( CK_LOG_SEVERE, "class 'Object'" );
+    EM_log( CK_LOG_HERALD, "class 'Object'" );
 
     const char * doc = "base class for all class types in ChucK.";
 
@@ -127,7 +127,7 @@ t_CKBOOL init_class_ugen( Chuck_Env * env, Chuck_Type * type )
 {
     Chuck_DL_Func * func = NULL;
 
-    EM_log( CK_LOG_SEVERE, "class 'UGen'" );
+    EM_log( CK_LOG_HERALD, "class 'UGen'" );
 
     // add ugen info
     type->ugen_info = new Chuck_UGen_Info;
@@ -229,7 +229,7 @@ t_CKBOOL init_class_uana( Chuck_Env * env, Chuck_Type * type )
 {
     Chuck_DL_Func * func = NULL;
 
-    EM_log( CK_LOG_SEVERE, "class 'UAna'" );
+    EM_log( CK_LOG_HERALD, "class 'UAna'" );
 
     // add uana info
     type->ugen_info = new Chuck_UGen_Info;
@@ -320,7 +320,7 @@ t_CKBOOL init_class_blob( Chuck_Env * env, Chuck_Type * type )
     // Chuck_Value * value = NULL;
 
     // log
-    EM_log( CK_LOG_SEVERE, "class 'UAnaBlob'" );
+    EM_log( CK_LOG_HERALD, "class 'UAnaBlob'" );
 
     const char * doc = "a data structure that contains results associated with UAna analysis. There is a UAnaBlob associated with every UAna. As a UAna is upchucked (using .upchuck()), the result is stored in the UAnaBlob's floating point vector and/or complex vector. The interpretation of the results depends on the specific UAna.";
 
@@ -393,7 +393,7 @@ t_CKBOOL init_class_event( Chuck_Env * env, Chuck_Type * type )
     Chuck_Value * value = NULL;
 
     // log
-    EM_log( CK_LOG_SEVERE, "class 'Event'" );
+    EM_log( CK_LOG_HERALD, "class 'Event'" );
 
     const char *doc = "a mechanism for precise synchronization across shreds.";
 
@@ -485,7 +485,7 @@ t_CKBOOL init_class_shred( Chuck_Env * env, Chuck_Type * type )
     Chuck_DL_Func * func = NULL;
 
     // log
-    EM_log( CK_LOG_SEVERE, "class 'Shred'" );
+    EM_log( CK_LOG_HERALD, "class 'Shred'" );
 
     const char *doc = "a strongly-timed ChucK thread of execution.";
 
@@ -653,7 +653,7 @@ t_CKBOOL init_class_vec2( Chuck_Env * env, Chuck_Type * type )
     Chuck_DL_Func * func = NULL;
 
     // log
-    EM_log( CK_LOG_SEVERE, "class 'vec2' (primitive)" );
+    EM_log( CK_LOG_HERALD, "class 'vec2' (primitive)" );
 
     // document
     const char * doc = "a primitive type for a 2-dimensional vector; potentially useful for 2D and UV coordinates.";
@@ -706,7 +706,7 @@ t_CKBOOL init_class_vec3( Chuck_Env * env, Chuck_Type * type )
     Chuck_DL_Func * func = NULL;
 
     // log
-    EM_log( CK_LOG_SEVERE, "class 'vec3' (primitive)" );
+    EM_log( CK_LOG_HERALD, "class 'vec3' (primitive)" );
 
     // document
     const char *doc = "a primitive type for a 3-dimensional vector; potentially useful for 3D coordinate, RGB color, or as a value/goal/slew interpolator.";
@@ -796,7 +796,7 @@ t_CKBOOL init_class_vec4( Chuck_Env * env, Chuck_Type * type )
     Chuck_DL_Func * func = NULL;
 
     // log
-    EM_log( CK_LOG_SEVERE, "class 'vec4' (primitive)" );
+    EM_log( CK_LOG_HERALD, "class 'vec4' (primitive)" );
 
     // document
     const char *doc = "a primitive type for a 4-dimensional vector; potentially useful for 4D coordinate and RGBA color.";
@@ -851,7 +851,7 @@ t_CKBOOL init_class_string( Chuck_Env * env, Chuck_Type * type )
     Chuck_DL_Func * func = NULL;
 
     // log
-    EM_log( CK_LOG_SEVERE, "class 'string'" );
+    EM_log( CK_LOG_HERALD, "class 'string'" );
 
     const char * doc = "textual data as a sequence of characters, along with functions for manipulating text.";
 
@@ -1081,7 +1081,7 @@ t_CKBOOL init_class_array( Chuck_Env * env, Chuck_Type * type )
     Chuck_DL_Func * func = NULL;
 
     // log
-    EM_log( CK_LOG_SEVERE, "class 'array'" );
+    EM_log( CK_LOG_HERALD, "class 'array'" );
 
     // init as base class
     // TODO: ctor/dtor?
@@ -1256,7 +1256,7 @@ error:
 t_CKBOOL init_class_function( Chuck_Env * env, Chuck_Type * type )
 {
     // log
-    EM_log( CK_LOG_SEVERE, "class '@function'" );
+    EM_log( CK_LOG_HERALD, "class '@function'" );
     const char * doc = "the base function Type.";
 
     // init as base class
@@ -1290,7 +1290,7 @@ t_CKBOOL init_class_type( Chuck_Env * env, Chuck_Type * type )
     Chuck_DL_Func * func = NULL;
 
     // log
-    EM_log( CK_LOG_SEVERE, "class 'Type'" );
+    EM_log( CK_LOG_HERALD, "class 'Type'" );
     const char * doc = "a representation of a ChucK type.";
 
     // init as base class

--- a/src/core/chuck_oo.cpp
+++ b/src/core/chuck_oo.cpp
@@ -204,7 +204,7 @@ void Chuck_VM_Object::unlock()
 void Chuck_VM_Object::lock_all()
 {
     // log
-    EM_log( CK_LOG_SEVERE, "locking down special objects..." );
+    EM_log( CK_LOG_HERALD, "locking down special objects..." );
     // set flag
     our_locks_in_effect = TRUE;
 }
@@ -219,7 +219,7 @@ void Chuck_VM_Object::lock_all()
 void Chuck_VM_Object::unlock_all()
 {
     // log
-    EM_log( CK_LOG_SEVERE, "unlocking special objects..." );
+    EM_log( CK_LOG_HERALD, "unlocking special objects..." );
     // set flag
     our_locks_in_effect = FALSE;
 }

--- a/src/core/chuck_type.cpp
+++ b/src/core/chuck_type.cpp
@@ -487,7 +487,7 @@ t_CKBOOL type_engine_init_special( Chuck_Env * env, Chuck_Type * objT )
 t_CKBOOL type_engine_init( Chuck_Carrier * carrier )
 {
     // log
-    EM_log( CK_LOG_SEVERE, "initializing type checker..." );
+    EM_log( CK_LOG_HERALD, "initializing type checker..." );
     // push indent level
     EM_pushlog();
 
@@ -551,7 +551,7 @@ t_CKBOOL type_engine_init( Chuck_Carrier * carrier )
     t_CKDUR eon = day * 365.256363004 * 1000000000.0;
 
     // add internal classes
-    EM_log( CK_LOG_SEVERE, "adding base classes..." );
+    EM_log( CK_LOG_HERALD, "adding base classes..." );
     EM_pushlog();
 
     // special: Object and Type, whose initializations mutually depend
@@ -717,7 +717,7 @@ t_CKBOOL type_engine_init( Chuck_Carrier * carrier )
 void type_engine_shutdown( Chuck_Carrier * carrier )
 {
     // log
-    EM_log( CK_LOG_SEVERE, "shutting down type system..." );
+    EM_log( CK_LOG_HERALD, "shutting down type system..." );
     // push
     EM_pushlog();
 
@@ -725,7 +725,7 @@ void type_engine_shutdown( Chuck_Carrier * carrier )
     CK_SAFE_DELETE( carrier->env );
 
     // log
-    EM_log( CK_LOG_SEVERE, "type system shutdown complete." );
+    EM_log( CK_LOG_HERALD, "type system shutdown complete." );
     // pop
     EM_poplog();
 }
@@ -7302,7 +7302,7 @@ t_CKBOOL type_engine_import_op_overload( Chuck_Env * env, Chuck_DL_Func * sfun )
 void type_engine_init_op_overload_builtin( Chuck_Env * env )
 {
     // log
-    EM_log( CK_LOG_SEVERE, "reserving default operator mappings..." );
+    EM_log( CK_LOG_HERALD, "reserving default operator mappings..." );
 
     // the registry
     Chuck_Op_Registry * registry = &env->op_registry;
@@ -7609,7 +7609,7 @@ void type_engine_init_op_overload_builtin( Chuck_Env * env )
 //-----------------------------------------------------------------------------
 t_CKBOOL type_engine_init_op_overload( Chuck_Env * env )
 {
-    EM_log( CK_LOG_SEVERE, "initializing operator mappings..." );
+    EM_log( CK_LOG_HERALD, "initializing operator mappings..." );
     EM_pushlog();
 
     // the registry
@@ -8543,7 +8543,7 @@ t_CKBOOL type_engine_add_dll2( Chuck_Env * env, Chuck_DLL * dll,
     {
         if( !type_engine_add_class_from_dl(env, query->classes[i]) )
         {
-            EM_log(CK_LOG_SEVERE,
+            EM_log(CK_LOG_HERALD,
                    TC::orange("error importing class '%s' from chugin (%s)",true).c_str(),
                    query->classes[i]->name.c_str(), dll->name());
 

--- a/src/core/chuck_vm.cpp
+++ b/src/core/chuck_vm.cpp
@@ -317,7 +317,7 @@ t_CKBOOL Chuck_VM::initialize_synthesis()
     }
 
     // log
-    EM_log( CK_LOG_SEVERE, "initializing 'dac'..." );
+    EM_log( CK_LOG_HERALD, "initializing 'dac'..." );
     // allocate dac and adc (REFACTOR-2017: g_t_dac changed to env()->ckt_dac)
     env()->ckt_dac->ugen_info->num_outs = env()->ckt_dac->ugen_info->num_ins = m_num_dac_channels;
     m_dac = (Chuck_UGen *)instantiate_and_initialize_object( env()->ckt_dac, this );
@@ -338,7 +338,7 @@ t_CKBOOL Chuck_VM::initialize_synthesis()
     m_dac->lock();
 
     // log
-    EM_log( CK_LOG_SEVERE, "initializing 'adc'..." );
+    EM_log( CK_LOG_HERALD, "initializing 'adc'..." );
     // (REFACTOR-2017: g_t_adc changed to env()->ckt_adc)
     env()->ckt_adc->ugen_info->num_ins = env()->ckt_adc->ugen_info->num_outs = m_num_adc_channels;
     m_adc = (Chuck_UGen *)instantiate_and_initialize_object( env()->ckt_adc, this );
@@ -359,7 +359,7 @@ t_CKBOOL Chuck_VM::initialize_synthesis()
     m_adc->lock();
 
     // log
-    EM_log( CK_LOG_SEVERE, "initializing 'blackhole'..." );
+    EM_log( CK_LOG_HERALD, "initializing 'blackhole'..." );
     m_bunghole = new Chuck_UGen;
     m_bunghole->add_ref();
     m_bunghole->lock();
@@ -401,7 +401,7 @@ t_CKBOOL Chuck_VM::shutdown()
     CK_SAFE_DELETE( m_globals_manager );
 
     // log
-    EM_log( CK_LOG_SEVERE, "removing shreds..." );
+    EM_log( CK_LOG_HERALD, "removing shreds..." );
     // removal all | 1.5.0.8 (ge) updated from previously non-functioning code
     this->removeAll();
 
@@ -428,7 +428,7 @@ t_CKBOOL Chuck_VM::shutdown()
 
     // log
     EM_pushlog();
-    EM_log( CK_LOG_SEVERE, "freeing dumped shreds..." );
+    EM_log( CK_LOG_HERALD, "freeing dumped shreds..." );
     // do it
     this->release_dump();
     EM_poplog();
@@ -1399,14 +1399,14 @@ t_CKBOOL Chuck_VM::abort_current_shred()
     if( shred )
     {
         // log
-        EM_log( CK_LOG_SEVERE, "trying to abort current shred (id: %lu)", shred->xid );
+        EM_log( CK_LOG_HERALD, "trying to abort current shred (id: %lu)", shred->xid );
         // flag it
         shred->is_abort = TRUE;
     }
     else
     {
         // log
-        EM_log( CK_LOG_SEVERE, "cannot abort shred: nothing currently running!" );
+        EM_log( CK_LOG_HERALD, "cannot abort shred: nothing currently running!" );
     }
 
     return shred != NULL;

--- a/src/core/ulib_std.cpp
+++ b/src/core/ulib_std.cpp
@@ -741,9 +741,9 @@ CK_DLL_SFUN( system_impl )
     else
     {
         // log
-        EM_log( CK_LOG_SEVERE, "invoking system( CMD )..." );
+        EM_log( CK_LOG_HERALD, "invoking system( CMD )..." );
         EM_pushlog();
-        EM_log( CK_LOG_SEVERE, "CMD: \"%s\"", cmd );
+        EM_log( CK_LOG_HERALD, "CMD: \"%s\"", cmd );
         EM_poplog();
         RETURN->v_int = system( cmd );
     }
@@ -1072,7 +1072,7 @@ t_CKBOOL KBHitManager::init()
     the_buf = new CBufferAdvance;
     if( !the_buf->initialize( BUFFER_SIZE, sizeof(t_CKINT) ) )
     {
-        EM_log( CK_LOG_SEVERE, "KBHitManager: couldn't allocate central KB buffer..." );
+        EM_log( CK_LOG_HERALD, "KBHitManager: couldn't allocate central KB buffer..." );
         CK_SAFE_DELETE( the_buf );
         return FALSE;
     }

--- a/src/core/util_console.cpp
+++ b/src/core/util_console.cpp
@@ -116,7 +116,7 @@ t_CKBOOL kb_initscr()
     struct termios term;
     if( tcgetattr(0, &term) == -1 )
     { 
-        EM_log( CK_LOG_SEVERE, "(kbhit disabled): standard input not a tty!");
+        EM_log( CK_LOG_HERALD, "(kbhit disabled): standard input not a tty!");
         return FALSE;
     }
 

--- a/src/core/util_hid.cpp
+++ b/src/core/util_hid.cpp
@@ -1019,7 +1019,7 @@ t_CKINT OSX_Hid_Device::start()
             // error during configuration!
             this->unlock();
 
-            EM_log( CK_LOG_SEVERE, "hid: error configuring %s", name );
+            EM_log( CK_LOG_HERALD, "hid: error configuring %s", name );
             EM_poplog();
 
             return -1;
@@ -1034,7 +1034,7 @@ t_CKINT OSX_Hid_Device::start()
     IOReturn result = ( *queue )->start( queue );
     if( result != kIOReturnSuccess )
     {
-        EM_log( CK_LOG_SEVERE, "hid: error starting event queue for %s", name );
+        EM_log( CK_LOG_HERALD, "hid: error starting event queue for %s", name );
         EM_poplog();
         return -1;
     }
@@ -1440,7 +1440,7 @@ void Hid_init2()
     CFMutableDictionaryRef hidMatchDictionary = IOServiceMatching( kIOHIDDeviceKey );
     if( !hidMatchDictionary )
     {
-        EM_log( CK_LOG_SEVERE, "hid: error: unable to retrieving hidMatchDictionary, unable to initialize" );
+        EM_log( CK_LOG_HERALD, "hid: error: unable to retrieving hidMatchDictionary, unable to initialize" );
         return;
     }
 
@@ -1466,7 +1466,7 @@ void Hid_init2()
 
     if( result != kIOReturnSuccess || hidObjectIterator == 0 )
     {
-        EM_log( CK_LOG_SEVERE, "hid: error: unable to retrieving matching services, unable to initialize" );
+        EM_log( CK_LOG_HERALD, "hid: error: unable to retrieving matching services, unable to initialize" );
         return;
     }
 
@@ -2081,7 +2081,7 @@ static void Hid_do_operation( void * info )
             case OSX_Hid_op::open:
                 if( op.index >= op.v->size() )
                 {
-                    EM_log( CK_LOG_SEVERE, "hid: error: no such device %i", op.index );
+                    EM_log( CK_LOG_HERALD, "hid: error: no such device %i", op.index );
                     return;
                 }
 
@@ -2097,7 +2097,7 @@ static void Hid_do_operation( void * info )
             case OSX_Hid_op::close:
                 if( op.index >= op.v->size() )
                 {
-                    EM_log( CK_LOG_SEVERE, "hid: error: no such device %i", op.index );
+                    EM_log( CK_LOG_HERALD, "hid: error: no such device %i", op.index );
                     return;
                 }
 
@@ -4878,7 +4878,7 @@ void Hid_init()
 
     g_device_event = CreateEvent( NULL, FALSE, FALSE, NULL );
     if( g_device_event == NULL )
-        EM_log( CK_LOG_SEVERE, "hid: error: unable to create event (win32 error %i)", GetLastError() );
+        EM_log( CK_LOG_HERALD, "hid: error: unable to create event (win32 error %i)", GetLastError() );
     g_wait_function = Hid_wait_event;
 }
 
@@ -5029,7 +5029,7 @@ void Joystick_init()
 #endif
         {
             lpdi = NULL;
-            EM_log( CK_LOG_SEVERE, "error: unable to initialize DirectInput, initialization failed" );
+            EM_log( CK_LOG_HERALD, "error: unable to initialize DirectInput, initialization failed" );
             EM_poplog();
             return;
         }
@@ -5059,7 +5059,7 @@ void Joystick_init()
         joysticks = NULL;
         lpdi->Release();
         lpdi = NULL;
-        EM_log( CK_LOG_SEVERE, "error: unable to enumerate devices, initialization failed" );
+        EM_log( CK_LOG_HERALD, "error: unable to enumerate devices, initialization failed" );
         EM_poplog();
         return;
     }
@@ -5801,7 +5801,7 @@ void Keyboard_init()
 #endif
         {
             lpdi = NULL;
-            EM_log( CK_LOG_SEVERE, "error: unable to initialize DirectInput, initialization failed" );
+            EM_log( CK_LOG_HERALD, "error: unable to initialize DirectInput, initialization failed" );
             EM_poplog();
             return;
         }
@@ -5819,7 +5819,7 @@ void Keyboard_init()
         keyboards = NULL;
         lpdi->Release();
         lpdi = NULL;
-        EM_log( CK_LOG_SEVERE, "error: unable to enumerate devices, initialization failed" );
+        EM_log( CK_LOG_HERALD, "error: unable to enumerate devices, initialization failed" );
         EM_poplog();
         return;
     }
@@ -7117,7 +7117,7 @@ void Hid_init()
     int filedes[2];
     if( pipe( filedes ) )
     {
-        EM_log( CK_LOG_SEVERE, "hid: unable to create pipe, initialization failed" );
+        EM_log( CK_LOG_HERALD, "hid: unable to create pipe, initialization failed" );
         return;
     }
 
@@ -7348,14 +7348,14 @@ int Joystick_open( int js )
     {
         if( ( joystick->fd = open( joystick->filename, O_RDONLY | O_NONBLOCK ) ) < 0 )
         {
-            EM_log( CK_LOG_SEVERE, "joystick: unable to open %s: %s", joystick->filename, strerror( errno ) );
+            EM_log( CK_LOG_HERALD, "joystick: unable to open %s: %s", joystick->filename, strerror( errno ) );
             return -1;
         }
 
         hid_channel_msg hcm = { HID_CHANNEL_OPEN, joystick };
         if(write( hid_channel_w, &hcm, sizeof( hcm ) ) == -1)
         {
-            EM_log( CK_LOG_SEVERE, "joystick: unable to write channel message %s: %s",
+            EM_log( CK_LOG_HERALD, "joystick: unable to write channel message %s: %s",
                 joystick->filename, strerror( errno ) );
             return -1;
         }
@@ -7379,7 +7379,7 @@ int Joystick_close( int js )
     {
         hid_channel_msg hcm = { HID_CHANNEL_CLOSE, joystick };
         if(write( hid_channel_w, &hcm, sizeof( hcm ) ) == -1) return -1;
-            EM_log( CK_LOG_SEVERE, "joystick: unable complete close message: %s",
+            EM_log( CK_LOG_HERALD, "joystick: unable complete close message: %s",
                  strerror( errno ) );
     }
 
@@ -7552,7 +7552,7 @@ int Mouse_open( int m )
     {
         if( ( mouse->fd = open( mouse->filename, O_RDONLY | O_NONBLOCK ) ) < 0 )
         {
-            EM_log( CK_LOG_SEVERE, "mouse: unable to open %s: %s", mouse->filename, strerror( errno ) );
+            EM_log( CK_LOG_HERALD, "mouse: unable to open %s: %s", mouse->filename, strerror( errno ) );
             return -1;
         }
 
@@ -7560,7 +7560,7 @@ int Mouse_open( int m )
         hid_channel_msg hcm = { HID_CHANNEL_OPEN, mouse };
         if(write( hid_channel_w, &hcm, sizeof( hcm ) ) == -1)
         {
-            EM_log( CK_LOG_SEVERE, "mouse: unable to complete open message %: %s", strerror( errno ) );
+            EM_log( CK_LOG_HERALD, "mouse: unable to complete open message %: %s", strerror( errno ) );
             return -1;
         }
     }
@@ -7748,14 +7748,14 @@ int Keyboard_open( int k )
     {
         if( ( keyboard->fd = open( keyboard->filename, O_RDONLY | O_NONBLOCK ) ) < 0 )
         {
-            EM_log( CK_LOG_SEVERE, "keyboard: unable to open %s: %s", keyboard->filename, strerror( errno ) );
+            EM_log( CK_LOG_HERALD, "keyboard: unable to open %s: %s", keyboard->filename, strerror( errno ) );
             return -1;
         }
 
         hid_channel_msg hcm = { HID_CHANNEL_OPEN, keyboard };
         if(write( hid_channel_w, &hcm, sizeof( hcm ) ) == -1)
         {
-            EM_log( CK_LOG_SEVERE, "keyboard: unable to write open message: %s", strerror( errno ) );
+            EM_log( CK_LOG_HERALD, "keyboard: unable to write open message: %s", strerror( errno ) );
             return -1;
         }
     }

--- a/src/core/util_opsc.cpp
+++ b/src/core/util_opsc.cpp
@@ -2172,7 +2172,7 @@ void
 OSC_Address_Space::setSpec( const char *addr, const char * types ) {
     if( snprintf( _spec, sizeof _spec, "%s,%s", addr, types ) >= sizeof _spec) {
         // TODO: handle the overflow more gracefully.
-        EM_log(CK_LOG_SEVERE, "OSC_Address_Space::setSpec: Not enough space in _spec buffer, data was truncated.");
+        EM_log(CK_LOG_HERALD, "OSC_Address_Space::setSpec: Not enough space in _spec buffer, data was truncated.");
     }
     scanSpec();
     _needparse = true;
@@ -2390,17 +2390,17 @@ bool OSC_Address_Space::vcheck( osc_datatype tt )
 {
     if( !_cur_mesg )
     {
-        EM_log( CK_LOG_SEVERE, "OscEvent: getVal(): nextMsg() must be called before reading data..." );
+        EM_log( CK_LOG_HERALD, "OscEvent: getVal(): nextMsg() must be called before reading data..." );
         return false;
     }
     else if( _cur_value < 0 || _cur_value >= _dataSize )
     {
-        EM_log( CK_LOG_SEVERE, "OscEvent: read position %d outside message ...", _cur_value );
+        EM_log( CK_LOG_HERALD, "OscEvent: read position %d outside message ...", _cur_value );
         return false;
     }
     else if( _cur_mesg[_cur_value].t != tt )
     {
-        EM_log( CK_LOG_SEVERE, "OscEvent: error -> message type %s != request type %s", osc_typename_strings[_cur_mesg[_cur_value].t], osc_typename_strings[tt]  );
+        EM_log( CK_LOG_HERALD, "OscEvent: error -> message type %s != request type %s", osc_typename_strings[_cur_mesg[_cur_value].t], osc_typename_strings[tt]  );
         return false;
     }
 

--- a/src/core/util_thread.cpp
+++ b/src/core/util_thread.cpp
@@ -340,7 +340,7 @@ size_t XWriteThread::fwrite(const void * ptr, size_t size, size_t nitems, FILE *
     // TODO: overflow detection
     if( m_data_buffer->put((char*)ptr, size*nitems) == 0 )
     {
-        EM_log( CK_LOG_SEVERE, "XWriteThread::fwrite(): data buffer overflow!" );
+        EM_log( CK_LOG_HERALD, "XWriteThread::fwrite(): data buffer overflow!" );
     }
 
     m_bytes_in_buffer += size*nitems;
@@ -458,7 +458,7 @@ unsigned XWriteThread::write_cb(void * _thiss)
                                                                msg.write.data_size);
                 if(actual_size != msg.write.data_size)
                 {
-                    EM_log( CK_LOG_SEVERE, "XWriteThread: buffered data size mismatch (%li : %li)",
+                    EM_log( CK_LOG_HERALD, "XWriteThread: buffered data size mismatch (%li : %li)",
                             msg.write.data_size, actual_size );
                 }
 

--- a/src/host/chuck_audio.cpp
+++ b/src/host/chuck_audio.cpp
@@ -565,7 +565,7 @@ static unsigned int __stdcall watch_dog( void * )
     t_CKUINT priority = XThreadUtil::our_priority;
 
     // log
-    EM_log( CK_LOG_SEVERE, "starting real-time watch dog process..." );
+    EM_log( CK_LOG_HERALD, "starting real-time watch dog process..." );
     // push log
     EM_pushlog();
     EM_log( CK_LOG_INFO, "watchdog timeout: %f::second", g_watchdog_timeout );
@@ -592,7 +592,7 @@ static unsigned int __stdcall watch_dog( void * )
             if( time - g_watchdog_time > g_watchdog_timeout )
             {
                 // log
-                EM_log( CK_LOG_SEVERE, "real-time watchdog counter-measure activating..." );
+                EM_log( CK_LOG_HERALD, "real-time watchdog counter-measure activating..." );
                 // lowering priority
                 if( g_tid_synthesis && XThreadUtil::our_priority != 0x7fffffff )
                     XThreadUtil::set_priority( g_tid_synthesis, g_watchdog_countermeasure_priority );
@@ -606,7 +606,7 @@ static unsigned int __stdcall watch_dog( void * )
             if( time - g_watchdog_time < g_watchdog_timeout )
             {
                 // log
-                EM_log( CK_LOG_SEVERE, "real-time watchdog resting..." );
+                EM_log( CK_LOG_HERALD, "real-time watchdog resting..." );
                 // raise priority
                 if( g_tid_synthesis && XThreadUtil::our_priority != 0x7fffffff )
                     XThreadUtil::set_priority( g_tid_synthesis, XThreadUtil::our_priority );
@@ -620,7 +620,7 @@ static unsigned int __stdcall watch_dog( void * )
     }
     
     // log
-    EM_log( CK_LOG_SEVERE, "stopping real-time watch dog process..." );
+    EM_log( CK_LOG_HERALD, "stopping real-time watch dog process..." );
 
     return 0;
 }
@@ -900,7 +900,7 @@ t_CKBOOL ChuckAudio::initialize( t_CKUINT dac_device,
             if( nextHighest >= 0 )
             {
                 // log
-                EM_log( CK_LOG_SEVERE, "new sample rate (next highest): %d -> %d",
+                EM_log( CK_LOG_HERALD, "new sample rate (next highest): %d -> %d",
                         sample_rate, device_info.sampleRates[nextHighest] );
                 // update sampling rate
                 m_sample_rate = sample_rate = device_info.sampleRates[nextHighest];
@@ -908,7 +908,7 @@ t_CKBOOL ChuckAudio::initialize( t_CKUINT dac_device,
             else if( closestIndex >= 0 ) // nothing higher
             {
                 // log
-                EM_log( CK_LOG_SEVERE, "new sample rate (closest): %d -> %d",
+                EM_log( CK_LOG_HERALD, "new sample rate (closest): %d -> %d",
                         sample_rate, device_info.sampleRates[closestIndex] );
                 // update sampling rate
                 m_sample_rate = sample_rate = device_info.sampleRates[closestIndex];
@@ -1001,9 +1001,9 @@ t_CKBOOL ChuckAudio::initialize( t_CKUINT dac_device,
                             // set to 0
                             m_num_channels_in = 0;
                             // log
-                            EM_log( CK_LOG_SEVERE, "cannot find compatible audio input device..." );
+                            EM_log( CK_LOG_HERALD, "cannot find compatible audio input device..." );
                             EM_pushlog();
-                                EM_log(CK_LOG_SEVERE, "defaulting to half-duplex (no audio input)...");
+                                EM_log(CK_LOG_HERALD, "defaulting to half-duplex (no audio input)...");
                             EM_poplog();
 
                             // problem finding audio devices, most likely
@@ -1083,7 +1083,7 @@ t_CKBOOL ChuckAudio::initialize( t_CKUINT dac_device,
     // check bufsize
     if( bufsize != (int)m_buffer_size )
     {
-        EM_log( CK_LOG_SEVERE, "new buffer size: %d -> %i", m_buffer_size, bufsize );
+        EM_log( CK_LOG_HERALD, "new buffer size: %d -> %i", m_buffer_size, bufsize );
         m_buffer_size = bufsize;
     }
 
@@ -1103,7 +1103,7 @@ t_CKBOOL ChuckAudio::initialize( t_CKUINT dac_device,
     m_num_channels_max = num_dac_channels > num_adc_channels ?
                          num_dac_channels : num_adc_channels;
     // log
-    EM_log( CK_LOG_SEVERE, "allocating buffers for %d x %d samples...",
+    EM_log( CK_LOG_HERALD, "allocating buffers for %d x %d samples...",
             m_buffer_size, m_num_channels_max );
 
     // allocate buffers


### PR DESCRIPTION
chugins can now implement a "info query function" to provide chugin-specific information to be accessible from host, including:
    * chugin version (not to be confused with compatibility version)
    * chugin author(s)
    * chugin description
    * (optional) chugin URL
    * (optional) contact email

for example, in the chugin source:
```
// chugin info func
CK_DLL_INFO( MyChugin )
{
    // set info
    QUERY->setinfo( QUERY, CHUGIN_INFO_AUTHORS, "Ana B. Croft" );
    QUERY->setinfo( QUERY, CHUGIN_INFO_CHUGIN_VERSION, "v3.6.1" );
    QUERY->setinfo( QUERY, CHUGIN_INFO_DESCRIPTION, "what does it do?" );
    QUERY->setinfo( QUERY, CHUGIN_INFO_URL, "https://foo.com/FooBar" );
    QUERY->setinfo( QUERY, CHUGIN_INFO_EMAIL, "ana@foo.com" );
}
```
this information is read by the host (and will be read even if the API compatibility check fails, as long as the chugin implements the `CK_DLL_INFO` function)