### PR TITLE
preliminary FreeBSD support: it is treated like Linux in every respect

### DIFF
--- a/src/core/chuck_def.h
+++ b/src/core/chuck_def.h
@@ -260,13 +260,13 @@ typedef struct { SAMPLE re ; SAMPLE im ; } t_CKCOMPLEX_SAMPLE;
 // platform: linux
 // related macros: __LINUX_ALSA__ __LINUX_PULSE__ __LINUX_OSS__ __LINUX_JACK__ __UNIX_JACK__
 //-------------------------------------------
-#if defined(__linux__)
+#if defined(__linux__) || defined(__FreeBSD__)
 //-------------------------------------------
   #ifndef __PLATFORM_LINUX__
   #define __PLATFORM_LINUX__
   #endif
 //-------------------------------------------
-#endif // defined(__linux__)
+#endif // defined(__linux__) || defined(__FreeBSD__)
 //-------------------------------------------
 
 

--- a/src/core/lo/config.h
+++ b/src/core/lo/config.h
@@ -1,5 +1,5 @@
 
-#if defined(__APPLE__) || defined(__linux__)
+#if defined(__APPLE__) || defined(__linux__) || defined(__FreeBSD__)
 // 1.5.0.7 (ge) since this is in the lo/ sub-directory,
 // and does not include chuck_def.h, directly check platform macros
 // #if defined(__PLATFORM_APPLE__) || defined(__PLATFORM_LINUX__)
@@ -199,4 +199,4 @@
 /* Define to `unsigned int' if <sys/types.h> does not define. */
 /* #undef size_t */
 
-#endif // defined(__APPLE__) || defined(__linux__)
+#endif // defined(__APPLE__) || defined(__linux__) || defined(__FreeBSD__)

--- a/src/core/rtmidi.cpp
+++ b/src/core/rtmidi.cpp
@@ -794,7 +794,7 @@ void RtMidiOut :: sendMessage( std::vector<unsigned char> *message )
 // chuck
 // 1.5.0.7 (ge) since this does not include chuck_def.h, directly check platform macros
 // previously: #if defined(__LINUX_ALSASEQ__) || defined(__PLATFORM_LINUX__)
-#if defined(__linux__) // NOTE: requires ALSA for MIDI on Linux
+#if defined(__linux__) || defined(__FreeBSD__) // NOTE: requires ALSA for MIDI on Linux
 
 // The ALSA Sequencer API is based on the use of a callback function for
 // MIDI input.
@@ -1440,7 +1440,7 @@ void RtMidiOut :: sendMessage( std::vector<unsigned char> *message )
   snd_seq_drain_output(data->seq);
 }
 
-#endif // defined(__linux__)
+#endif // defined(__linux__) || defined(__FreeBSD__)
 
 
 //*********************************************************************//

--- a/src/core/util_hid.cpp
+++ b/src/core/util_hid.cpp
@@ -6376,8 +6376,8 @@ Linux general HID support
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <stdint.h>
 #include <dirent.h>
-#include <linux/unistd.h>
 #include <string.h>
 #include <fcntl.h>
 #include <sys/poll.h>
@@ -7033,7 +7033,7 @@ static void Keyboard_init_translation_table()
     kb_translation_table[KEY_F24] |= 0x73 << 8;
 }
 
-static void Keyboard_translate_key( __u16 evdev_key, long & ascii, long & usb )
+static void Keyboard_translate_key( uint16_t evdev_key, long & ascii, long & usb )
 {
     unsigned short tr = kb_translation_table[evdev_key];
 
@@ -7412,10 +7412,12 @@ void Mouse_configure( const char * filename )
     if( S_ISCHR( statbuf.st_mode ) == 0 )
         return; /* not a character device... */
 
+#ifndef __FreeBSD__
     devmajor = ( statbuf.st_rdev & 0xFF00 ) >> 8;
     devminor = ( statbuf.st_rdev & 0x00FF );
     if ( ( devmajor != 13 ) || ( devminor < 64 ) || ( devminor > 96 ) )
         return; /* not an evdev. */
+#endif
 
     if( ( fd = open( filename, O_RDONLY | O_NONBLOCK ) ) < 0 )
         return;
@@ -7619,10 +7621,12 @@ int Keyboard_configure( const char * filename )
     if( S_ISCHR( statbuf.st_mode ) == 0 )
         return HID_KB_CONFIG_INVALID; /* not a character device... */
 
+#ifndef __FreeBSD__
     devmajor = ( statbuf.st_rdev & 0xFF00 ) >> 8;
     devminor = ( statbuf.st_rdev & 0x00FF );
     if ( ( devmajor != 13 ) || ( devminor < 64 ) || ( devminor > 96 ) )
         return HID_KB_CONFIG_INVALID; /* not an evdev. */
+#endif
 
     if( ( fd = open( filename, O_RDONLY | O_NONBLOCK ) ) < 0 )
         return HID_KB_CONFIG_ERROR_CANTOPEN;

--- a/src/core/util_sndfile.h
+++ b/src/core/util_sndfile.h
@@ -176,7 +176,7 @@
 // #define HAVE_ALSA_ASOUNDLIB_H
 // #endif
 
-#if defined(__linux__) // Linux
+#if defined(__linux__) || defined(__FreeBSD__) // Linux and FreeBSD
 #define CPU_CLIPS_POSITIVE 0
 #define CPU_IS_BIG_ENDIAN 0
 #define CPU_IS_LITTLE_ENDIAN 1


### PR DESCRIPTION
This will need some discussion.

FreeBSD is compatible with Linux for all relevant APIs, so we simply define `__PLATFORM_LINUX__`.
The HID devices do not currently work, even though FreeBSD also supports evdev and I have everything set up for root-less access to evdev-devices. I am writing my own audio programming environment with evdev support, so I know it's working equally well on Linux and FreeBSD.
Is `chuck --probe` supposed to list the evdev devices as well?

I have tested only the Jack backend (linux-jack).

I will probably use ChucK only for some benchmarking, so I do not expect to work with it elaborately. However, some FreeBSD support is better than nothing.