### PR TITLE
Avoid crash from double-destroying LiSaX.

### DIFF
--- a/src/core/ugen_xxx.cpp
+++ b/src/core/ugen_xxx.cpp
@@ -4757,7 +4757,7 @@ CK_DLL_DTOR( LiSaMulti_dtor )
     // get data
     LiSaMulti_data * d = (LiSaMulti_data *)OBJ_MEMBER_UINT(SELF, LiSaMulti_offset_data);
     // clean up | 1.5.0.0 (ge) added
-    CK_SAFE_DELETE_ARRAY( d->outsamples );
+    if ( d ) CK_SAFE_DELETE_ARRAY( d->outsamples );
     // delete
     CK_SAFE_DELETE(d);
     // set


### PR DESCRIPTION
I don't know why it's being destroyed twice and this doesn't try to fix that. Maybe it's intentional, since `LiSaX` derives from `LiSa` but shares the same constructor/destructor in `type_engine_import_ugen_begin` calls?

When I add `EM_log( CK_LOG_CORE, "(lisa): destroying, d = %p", d);` inside `LiSaMulti_dtor`, I see indeed that it's called twice, once with a valid pointer and once with null. A similar test with e.g. `SinOsc` or the single-channel `LiSa` only reports one call to the dtor. 

Repro:
```
LiSa2 lisa; // or LiSa10, etc -- but not LiSa
// crashes
```
