### PR TITLE
fix KBHit leaving terminal in broken state

### DIFF
--- a/src/core/chuck.cpp
+++ b/src/core/chuck.cpp
@@ -58,6 +58,7 @@
 #include "util_network.h"
 #endif
 
+#include "ulib_std.h"
 #include "util_platforms.h"
 #include "util_string.h"
 #include "ugen_stk.h"
@@ -1510,7 +1511,7 @@ void ChucK::globalCleanup()
 
     #ifndef __DISABLE_KBHIT__
     // shutdown kb loop
-    // KBHitManager::shutdown();
+    KBHitManager::shutdown();
     #endif // __DISABLE_KBHIT__
 
     // pop


### PR DESCRIPTION
KBHitManager::shutdown() was not called in ChucK::globalCleanup() and terminal state was not restored after shutting down. Calling it seems to fix the problem.

I stumbled upon the problem described in #143. I think this is the solution proposed by @spencersalazar @lathertonj. After this change I am no longer experiencing the problem. Was this intentionally commented out?