### PR TITLE
added channel voice message to MidiOut

### DIFF
--- a/VERSIONS
+++ b/VERSIONS
@@ -7,7 +7,7 @@ ChucK VERSIONS log
 - (updated) chugin API version from 10.1 to 10.2
 - (added) chugin API for callback on shutdown
 - (added) chugin API for setting array elements (thanks azaday)
-- (added) overloaded constructors added (more to come) 
+- (added) overloaded constructors (more to come) 
 ==================
     Envelope( dur durationToTarget )
         Construct an Envelope with duration to reach target (assumed to be 1.0);
@@ -33,14 +33,38 @@ ChucK VERSIONS log
 ==================
 - (added) new member functions
 ==================
-    fun dur Envelope.ramp( dur durationToTarget, float target );
+    dur Envelope.ramp( dur durationToTarget, float target );
         Over the given duration, ramp toward the specified target; returns the given 
         duration.
-    fun dur Envelope.ramp( float secondsToTarget, float target );
+    dur Envelope.ramp( float secondsToTarget, float target );
         Over the given duration (in seconds), ramp toward the specified target; returns
         the given duration.
 ==================
 - (added) examples/basic/envelope2.ck -- to show Envelope.ramp() in action
+- (added) new MIDI message voice message convenience functions (thanks @cviejo;
+    previously these are possible only through `MidiOut.send( MidiMsg msg )`:
+==================
+    int MidiOut.send( int status, int data1, int data2 );
+        Send out a MIDI message consisting of one status byte and two data bytes.
+    int channelPressure(int channel, int pressure)
+        Send out a channelPressure message.
+    int controlChange(int channel, int controller, int value)
+        Send out a controlChange message.
+    int noteOff(int channel, int note, int velocity)
+        Send out a noteOff message.
+    int noteOn(int channel, int note, int velocity)
+        Send out a noteOn message.
+    int pitchBend(int channel, int value)
+        Send out a pitchBend message.
+    int pitchBend(int channel, int lsb, int msb)
+        Send out a pitchBend message with fine and coarse values.
+    int polyPressure(int channel, int note, int pressure)
+        Send out a polyPressure message.
+    int programChange(int channel, int program)
+        Send out a programChange message.
+==================
+- (added) examples/midi/midiout2.ck -- demonstrates using the above channel
+          voice messages
 - (added) examples/deep/smb.ck -- a ChucK rendition of Super Mario Bros.
           original theme by Koji Kondo; (meticulously) modeled in ChucK by 
           Wesley Burchell in 2017

--- a/examples/midi/midiout.ck
+++ b/examples/midi/midiout.ck
@@ -2,6 +2,7 @@
 // name: midiout.ck
 // desc: example of sending MIDI messages
 // note: for a good explanation of how MIDI messages work, see after the code
+//       also see midiout2.ck for sending by common channel voice message
 //-----------------------------------------------------------------------------
 
 // instantiate a MIDI out object

--- a/examples/midi/midiout2.ck
+++ b/examples/midi/midiout2.ck
@@ -1,6 +1,7 @@
 //-----------------------------------------------------------------------------
 // name: midiout2.ck
 // desc: example of sending MIDI messages using MidiOut only
+// requires: chuck-1.5.2.5 or higher | author: cviejo
 // note: for a good explanation of how MIDI messages work and sending raw midi
 //       messages, see midiout.ck
 //-----------------------------------------------------------------------------
@@ -16,34 +17,34 @@ if( !mout.open(0) ) me.exit();
 while( true )
 {
     <<< "sending note on message...", "" >>>;
-    mout.noteOn( 1, 60, 127 );
+    mout.noteOn( 0, 60, 127 );
     1::second => now;
 
     <<< "sending note off message...", "" >>>;
-    mout.noteOff( 1, 60, 0 );
+    mout.noteOff( 0, 60, 0 );
     1::second => now;
 
     <<< "sending control change message...", "" >>>;
-    mout.controlChange( 1, 14, 127 );
+    mout.controlChange( 0, 14, 127 );
     1::second => now;
 
     <<< "sending program change message...", "" >>>;
-    mout.programChange( 1, 6 );
+    mout.programChange( 0, 6 );
     1::second => now;
 
     <<< "sending polyphonic key pressure (aftertouch)...", "" >>>;
-    mout.polyPressure( 1, 60, 127 );
+    mout.polyPressure( 0, 60, 127 );
     1::second => now;
 
     <<< "sending channel pressure (aftertouch)...", "" >>>;
-    mout.channelPressure( 1, 127 );
+    mout.channelPressure( 0, 127 );
     1::second => now;
 
     <<< "sending pitch bend message...", "" >>>;
-    mout.pitchBend( 1, 96 ); // +50% or 1.00 semitone up
+    mout.pitchBend( 0, 96 ); // +50% or 1.00 semitone up
     1::second => now;
 
     <<< "sending fine resolution pitch bend message...", "" >>>;
-    mout.pitchBend( 1, 50, 96 ); // +51% or 1.01 semitone up
+    mout.pitchBend( 0, 50, 96 ); // +51% or 1.01 semitone up
     1::second => now;
 }

--- a/examples/midi/midiout2.ck
+++ b/examples/midi/midiout2.ck
@@ -1,0 +1,49 @@
+//-----------------------------------------------------------------------------
+// name: midiout2.ck
+// desc: example of sending MIDI messages using MidiOut only
+// note: for a good explanation of how MIDI messages work and sending raw midi
+//       messages, see midiout.ck
+//-----------------------------------------------------------------------------
+
+// instantiate a MIDI out object
+MidiOut mout;
+// open a MIDI device for output
+if( !mout.open(0) ) me.exit();
+
+<<< "MIDI output device opened...", "" >>>;
+
+// loop
+while( true )
+{
+    <<< "sending note on message...", "" >>>;
+    mout.noteOn( 1, 60, 127 );
+    1::second => now;
+
+    <<< "sending note off message...", "" >>>;
+    mout.noteOff( 1, 60, 0 );
+    1::second => now;
+
+    <<< "sending control change message...", "" >>>;
+    mout.controlChange( 1, 14, 127 );
+    1::second => now;
+
+    <<< "sending program change message...", "" >>>;
+    mout.programChange( 1, 6 );
+    1::second => now;
+
+    <<< "sending polyphonic key pressure (aftertouch)...", "" >>>;
+    mout.polyPressure( 1, 60, 127 );
+    1::second => now;
+
+    <<< "sending channel pressure (aftertouch)...", "" >>>;
+    mout.channelPressure( 1, 127 );
+    1::second => now;
+
+    <<< "sending pitch bend message...", "" >>>;
+    mout.pitchBend( 1, 96 ); // +50% or 1.00 semitone up
+    1::second => now;
+
+    <<< "sending fine resolution pitch bend message...", "" >>>;
+    mout.pitchBend( 1, 50, 96 ); // +51% or 1.01 semitone up
+    1::second => now;
+}

--- a/src/core/chuck_io.cpp
+++ b/src/core/chuck_io.cpp
@@ -908,7 +908,7 @@ t_CKBOOL init_class_Midi( Chuck_Env * env )
     func->doc = "Send out a pitchBend message.";
     if( !type_engine_import_mfun( env, func ) ) goto error;
 
-    // add pitchBend()
+    // add pitchBend() - fine resolution
     func = make_new_mfun( "int", "pitchBend", MidiOut_pitchBend_fine );
     func->add_arg( "int", "channel" );
     func->add_arg( "int", "lsb" );

--- a/src/core/chuck_io.cpp
+++ b/src/core/chuck_io.cpp
@@ -870,6 +870,67 @@ t_CKBOOL init_class_Midi( Chuck_Env * env )
     func->doc = "Send out a MidiMsg message.";
     if( !type_engine_import_mfun( env, func ) ) goto error;
 
+    // add noteOn()
+    func = make_new_mfun( "int", "noteOn", MidiOut_noteOn );
+    func->add_arg( "int", "channel" );
+    func->add_arg( "int", "note" );
+    func->add_arg( "int", "velocity" );
+    func->doc = "Send out a noteOn message.";
+    if( !type_engine_import_mfun( env, func ) ) goto error;
+
+    // add noteOff()
+    func = make_new_mfun( "int", "noteOff", MidiOut_noteOff );
+    func->add_arg( "int", "channel" );
+    func->add_arg( "int", "note" );
+    func->add_arg( "int", "velocity" );
+    func->doc = "Send out a noteOff message.";
+    if( !type_engine_import_mfun( env, func ) ) goto error;
+
+    // add controlChange()
+    func = make_new_mfun( "int", "controlChange", MidiOut_controlChange );
+    func->add_arg( "int", "channel" );
+    func->add_arg( "int", "controller" );
+    func->add_arg( "int", "value" );
+    func->doc = "Send out a controlChange message.";
+    if( !type_engine_import_mfun( env, func ) ) goto error;
+
+    // add programChange()
+    func = make_new_mfun( "int", "programChange", MidiOut_programChange );
+    func->add_arg( "int", "channel" );
+    func->add_arg( "int", "program" );
+    func->doc = "Send out a programChange message.";
+    if( !type_engine_import_mfun( env, func ) ) goto error;
+
+    // add pitchBend()
+    func = make_new_mfun( "int", "pitchBend", MidiOut_pitchBend );
+    func->add_arg( "int", "channel" );
+    func->add_arg( "int", "value" );
+    func->doc = "Send out a pitchBend message.";
+    if( !type_engine_import_mfun( env, func ) ) goto error;
+
+    // add pitchBend()
+    func = make_new_mfun( "int", "pitchBend", MidiOut_pitchBend_fine );
+    func->add_arg( "int", "channel" );
+    func->add_arg( "int", "lsb" );
+    func->add_arg( "int", "msb" );
+    func->doc = "Send out a pitchBend message with fine and coarse values.";
+    if( !type_engine_import_mfun( env, func ) ) goto error;
+
+    // add polyPressure()
+    func = make_new_mfun( "int", "polyPressure", MidiOut_polyPressure );
+    func->add_arg( "int", "channel" );
+    func->add_arg( "int", "note" );
+    func->add_arg( "int", "pressure" );
+    func->doc = "Send out a polyPressure message.";
+    if( !type_engine_import_mfun( env, func ) ) goto error;
+
+    // add channelPressure()
+    func = make_new_mfun( "int", "channelPressure", MidiOut_channelPressure );
+    func->add_arg( "int", "channel" );
+    func->add_arg( "int", "pressure" );
+    func->doc = "Send out a channelPressure message.";
+    if( !type_engine_import_mfun( env, func ) ) goto error;
+
     // add examples
     if( !type_engine_import_add_ex( env, "midi/midiout.ck" ) ) goto error;
 
@@ -2426,6 +2487,76 @@ CK_DLL_MFUN( MidiOut_send )
     the_msg.data[1] = (t_CKBYTE)OBJ_MEMBER_INT(fake_msg, MidiMsg_offset_data2);
     the_msg.data[2] = (t_CKBYTE)OBJ_MEMBER_INT(fake_msg, MidiMsg_offset_data3);
     RETURN->v_int = mout->send( &the_msg );
+}
+
+CK_DLL_MFUN( MidiOut_noteOn )
+{
+    MidiOut * mout = (MidiOut *)OBJ_MEMBER_INT(SELF, MidiOut_offset_data);
+    t_CKINT channel = GET_NEXT_INT(ARGS);
+    t_CKINT note = GET_NEXT_INT(ARGS);
+    t_CKINT velocity = GET_NEXT_INT(ARGS);
+    RETURN->v_int = mout->noteon( channel, note, velocity );
+}
+
+CK_DLL_MFUN( MidiOut_noteOff )
+{
+    MidiOut * mout = (MidiOut *)OBJ_MEMBER_INT(SELF, MidiOut_offset_data);
+    t_CKINT channel = GET_NEXT_INT(ARGS);
+    t_CKINT note = GET_NEXT_INT(ARGS);
+    t_CKINT velocity = GET_NEXT_INT(ARGS);
+    RETURN->v_int = mout->noteoff( channel, note, velocity );
+}
+
+CK_DLL_MFUN( MidiOut_controlChange )
+{
+    MidiOut * mout = (MidiOut *)OBJ_MEMBER_INT(SELF, MidiOut_offset_data);
+    t_CKINT channel = GET_NEXT_INT(ARGS);
+    t_CKINT control = GET_NEXT_INT(ARGS);
+    t_CKINT value = GET_NEXT_INT(ARGS);
+    RETURN->v_int = mout->ctrlchange( channel, control, value );
+}
+
+CK_DLL_MFUN( MidiOut_programChange )
+{
+    MidiOut * mout = (MidiOut *)OBJ_MEMBER_INT(SELF, MidiOut_offset_data);
+    t_CKINT channel = GET_NEXT_INT(ARGS);
+    t_CKINT program = GET_NEXT_INT(ARGS);
+    RETURN->v_int = mout->progchange( channel, program );
+}
+
+CK_DLL_MFUN( MidiOut_pitchBend )
+{
+    MidiOut * mout = (MidiOut *)OBJ_MEMBER_INT(SELF, MidiOut_offset_data);
+    t_CKINT channel = GET_NEXT_INT(ARGS);
+    t_CKINT value = GET_NEXT_INT(ARGS);
+    RETURN->v_int = mout->pitchbend( channel, value );
+}
+
+CK_DLL_MFUN( MidiOut_pitchBend_fine )
+{
+    MidiOut * mout = (MidiOut *)OBJ_MEMBER_INT(SELF, MidiOut_offset_data);
+    t_CKINT channel = GET_NEXT_INT(ARGS);
+    t_CKINT lsb = GET_NEXT_INT(ARGS);
+    t_CKINT msb = GET_NEXT_INT(ARGS);
+    RETURN->v_int = mout->pitchbendFine( channel, lsb, msb );
+}
+
+
+CK_DLL_MFUN( MidiOut_polyPressure )
+{
+    MidiOut * mout = (MidiOut *)OBJ_MEMBER_INT(SELF, MidiOut_offset_data);
+    t_CKINT channel = GET_NEXT_INT(ARGS);
+    t_CKINT note = GET_NEXT_INT(ARGS);
+    t_CKINT pressure = GET_NEXT_INT(ARGS);
+    RETURN->v_int = mout->polypress( channel, note, pressure );
+}
+
+CK_DLL_MFUN( MidiOut_channelPressure )
+{
+    MidiOut * mout = (MidiOut *)OBJ_MEMBER_INT(SELF, MidiOut_offset_data);
+    t_CKINT channel = GET_NEXT_INT(ARGS);
+    t_CKINT pressure = GET_NEXT_INT(ARGS);
+    RETURN->v_int = mout->chanpress( channel, pressure );
 }
 
 #endif // __DISABLE_MIDI__

--- a/src/core/chuck_io.h
+++ b/src/core/chuck_io.h
@@ -542,6 +542,14 @@ CK_DLL_MFUN( MidiOut_num );
 CK_DLL_MFUN( MidiOut_name );
 CK_DLL_MFUN( MidiOut_printerr );
 CK_DLL_MFUN( MidiOut_send );
+CK_DLL_MFUN( MidiOut_noteOn );
+CK_DLL_MFUN( MidiOut_noteOff );
+CK_DLL_MFUN( MidiOut_controlChange );
+CK_DLL_MFUN( MidiOut_programChange );
+CK_DLL_MFUN( MidiOut_pitchBend );
+CK_DLL_MFUN( MidiOut_pitchBend_fine );
+CK_DLL_MFUN( MidiOut_polyPressure );
+CK_DLL_MFUN( MidiOut_channelPressure );
 #endif // __DISABLE_MIDI__
 
 

--- a/src/core/chuck_io.h
+++ b/src/core/chuck_io.h
@@ -542,6 +542,7 @@ CK_DLL_MFUN( MidiOut_num );
 CK_DLL_MFUN( MidiOut_name );
 CK_DLL_MFUN( MidiOut_printerr );
 CK_DLL_MFUN( MidiOut_send );
+CK_DLL_MFUN( MidiOut_send_msg );
 CK_DLL_MFUN( MidiOut_noteOn );
 CK_DLL_MFUN( MidiOut_noteOff );
 CK_DLL_MFUN( MidiOut_controlChange );

--- a/src/core/midiio_rtmidi.cpp
+++ b/src/core/midiio_rtmidi.cpp
@@ -102,7 +102,7 @@ t_CKUINT MidiOut::send( t_CKBYTE status )
 // note: previously, this was sending a 3 byte message with data2 = 0, this was
 //       causing a problem on macOS (only) where rtmidi was sending two program
 //       change messages instead of one. This was fixed by sending a 2 byte
-//       message.
+//       message | 1.5.2.5 (cviejo)
 //-----------------------------------------------------------------------------
 t_CKUINT MidiOut::send( t_CKBYTE status, t_CKBYTE data1 )
 {
@@ -225,7 +225,7 @@ t_CKBOOL MidiOut::close( )
 // desc: note on message
 //-----------------------------------------------------------------------------
 t_CKUINT MidiOut::noteon( t_CKUINT channel, t_CKUINT note, t_CKUINT velocity )
-{ return this->send( (t_CKBYTE)(MIDI_NOTEON + channel - 1), note, velocity ); }
+{ return this->send( (t_CKBYTE)(MIDI_NOTEON + channel), note, velocity ); }
 
 
 
@@ -235,7 +235,7 @@ t_CKUINT MidiOut::noteon( t_CKUINT channel, t_CKUINT note, t_CKUINT velocity )
 // desc: note off message
 //-----------------------------------------------------------------------------
 t_CKUINT MidiOut::noteoff( t_CKUINT channel, t_CKUINT note, t_CKUINT velocity )
-{ return this->send( (t_CKBYTE)(MIDI_NOTEOFF + channel - 1), note, velocity ); }
+{ return this->send( (t_CKBYTE)(MIDI_NOTEOFF + channel), note, velocity ); }
 
 
 
@@ -245,7 +245,7 @@ t_CKUINT MidiOut::noteoff( t_CKUINT channel, t_CKUINT note, t_CKUINT velocity )
 // desc: polypress message
 //-----------------------------------------------------------------------------
 t_CKUINT MidiOut::polypress( t_CKUINT channel, t_CKUINT note, t_CKUINT pressure )
-{ return this->send( (t_CKBYTE)(MIDI_POLYPRESS + channel - 1), note, pressure ); }
+{ return this->send( (t_CKBYTE)(MIDI_POLYPRESS + channel), note, pressure ); }
 
 
 
@@ -255,7 +255,7 @@ t_CKUINT MidiOut::polypress( t_CKUINT channel, t_CKUINT note, t_CKUINT pressure 
 // desc: ctrl change message
 //-----------------------------------------------------------------------------
 t_CKUINT MidiOut::ctrlchange( t_CKUINT channel, t_CKUINT ctrl_num, t_CKUINT ctrl_val )
-{ return this->send( (t_CKBYTE)(MIDI_CTRLCHANGE + channel - 1), ctrl_num, ctrl_val ); }
+{ return this->send( (t_CKBYTE)(MIDI_CTRLCHANGE + channel), ctrl_num, ctrl_val ); }
 
 
 
@@ -265,7 +265,7 @@ t_CKUINT MidiOut::ctrlchange( t_CKUINT channel, t_CKUINT ctrl_num, t_CKUINT ctrl
 // desc: prog change message
 //-----------------------------------------------------------------------------
 t_CKUINT MidiOut::progchange( t_CKUINT channel, t_CKUINT patch )
-{ return this->send( (t_CKBYTE)(MIDI_PROGCHANGE + channel - 1), patch ); }
+{ return this->send( (t_CKBYTE)(MIDI_PROGCHANGE + channel), patch ); }
 
 
 
@@ -275,7 +275,8 @@ t_CKUINT MidiOut::progchange( t_CKUINT channel, t_CKUINT patch )
 // desc: chan press
 //-----------------------------------------------------------------------------
 t_CKUINT MidiOut::chanpress( t_CKUINT channel, t_CKUINT pressure )
-{ return this->send( (t_CKBYTE)(MIDI_CHANPRESS + channel - 1), pressure ); }
+{ return this->send( (t_CKBYTE)(MIDI_CHANPRESS + channel), pressure ); }
+
 
 
 
@@ -284,7 +285,8 @@ t_CKUINT MidiOut::chanpress( t_CKUINT channel, t_CKUINT pressure )
 // desc: pitch bend
 //-----------------------------------------------------------------------------
 t_CKUINT MidiOut::pitchbendFine( t_CKUINT channel, t_CKUINT lsb, t_CKUINT msb)
-{ return this->send( (t_CKBYTE)(MIDI_PITCHBEND + channel - 1), lsb, msb ); }
+{ return this->send( (t_CKBYTE)(MIDI_PITCHBEND + channel), lsb, msb ); }
+
 
 
 
@@ -294,6 +296,7 @@ t_CKUINT MidiOut::pitchbendFine( t_CKUINT channel, t_CKUINT lsb, t_CKUINT msb)
 //-----------------------------------------------------------------------------
 t_CKUINT MidiOut::pitchbend( t_CKUINT channel, t_CKUINT bend_val )
 { return this->pitchbendFine( channel, 0, bend_val ); }
+
 
 
 

--- a/src/core/midiio_rtmidi.cpp
+++ b/src/core/midiio_rtmidi.cpp
@@ -99,6 +99,10 @@ t_CKUINT MidiOut::send( t_CKBYTE status )
 //-----------------------------------------------------------------------------
 // name: send()
 // desc: send 2 byte midi message
+// note: previously, this was sending a 3 byte message with data2 = 0, this was
+//       causing a problem on macOS (only) where rtmidi was sending two program
+//       change messages instead of one. This was fixed by sending a 2 byte
+//       message.
 //-----------------------------------------------------------------------------
 t_CKUINT MidiOut::send( t_CKBYTE status, t_CKBYTE data1 )
 {
@@ -296,6 +300,9 @@ t_CKUINT MidiOut::pitchbend( t_CKUINT channel, t_CKUINT bend_val )
 //-----------------------------------------------------------------------------
 // name: allnotesoff()
 // desc: allnotesoff
+// note: allnotesoff and others are channel mode messages, not that commonly
+//       used and very easy to implement with MidiOut::ctrlchange so we're not
+//       exposing them for now.
 //-----------------------------------------------------------------------------
 t_CKUINT MidiOut::allnotesoff( t_CKUINT channel )
 { return this->ctrlchange( channel, 123, 0 ); }

--- a/src/core/midiio_rtmidi.cpp
+++ b/src/core/midiio_rtmidi.cpp
@@ -102,7 +102,17 @@ t_CKUINT MidiOut::send( t_CKBYTE status )
 //-----------------------------------------------------------------------------
 t_CKUINT MidiOut::send( t_CKBYTE status, t_CKBYTE data1 )
 {
-    return this->send( status, data1, 0 );
+    if( !m_valid ) return 0;
+
+    // clear
+    m_msg.clear();
+    // add
+    m_msg.push_back( status );
+    m_msg.push_back( data1 );
+
+    mout->sendMessage( &m_msg );
+
+    return 2;
 }
 
 
@@ -211,7 +221,7 @@ t_CKBOOL MidiOut::close( )
 // desc: note on message
 //-----------------------------------------------------------------------------
 t_CKUINT MidiOut::noteon( t_CKUINT channel, t_CKUINT note, t_CKUINT velocity )
-{ return this->send( (t_CKBYTE)(MIDI_NOTEON + channel), note, velocity ); }
+{ return this->send( (t_CKBYTE)(MIDI_NOTEON + channel - 1), note, velocity ); }
 
 
 
@@ -221,7 +231,7 @@ t_CKUINT MidiOut::noteon( t_CKUINT channel, t_CKUINT note, t_CKUINT velocity )
 // desc: note off message
 //-----------------------------------------------------------------------------
 t_CKUINT MidiOut::noteoff( t_CKUINT channel, t_CKUINT note, t_CKUINT velocity )
-{ return this->send( (t_CKBYTE)(MIDI_NOTEOFF + channel), note, velocity ); }
+{ return this->send( (t_CKBYTE)(MIDI_NOTEOFF + channel - 1), note, velocity ); }
 
 
 
@@ -231,7 +241,7 @@ t_CKUINT MidiOut::noteoff( t_CKUINT channel, t_CKUINT note, t_CKUINT velocity )
 // desc: polypress message
 //-----------------------------------------------------------------------------
 t_CKUINT MidiOut::polypress( t_CKUINT channel, t_CKUINT note, t_CKUINT pressure )
-{ return this->send( (t_CKBYTE)(MIDI_POLYPRESS + channel), note, pressure ); }
+{ return this->send( (t_CKBYTE)(MIDI_POLYPRESS + channel - 1), note, pressure ); }
 
 
 
@@ -241,7 +251,7 @@ t_CKUINT MidiOut::polypress( t_CKUINT channel, t_CKUINT note, t_CKUINT pressure 
 // desc: ctrl change message
 //-----------------------------------------------------------------------------
 t_CKUINT MidiOut::ctrlchange( t_CKUINT channel, t_CKUINT ctrl_num, t_CKUINT ctrl_val )
-{ return this->send( (t_CKBYTE)(MIDI_CTRLCHANGE + channel), ctrl_num, ctrl_val ); }
+{ return this->send( (t_CKBYTE)(MIDI_CTRLCHANGE + channel - 1), ctrl_num, ctrl_val ); }
 
 
 
@@ -251,7 +261,7 @@ t_CKUINT MidiOut::ctrlchange( t_CKUINT channel, t_CKUINT ctrl_num, t_CKUINT ctrl
 // desc: prog change message
 //-----------------------------------------------------------------------------
 t_CKUINT MidiOut::progchange( t_CKUINT channel, t_CKUINT patch )
-{ return this->send( (t_CKBYTE)(MIDI_PROGCHANGE + channel), patch, 0 ); }
+{ return this->send( (t_CKBYTE)(MIDI_PROGCHANGE + channel - 1), patch ); }
 
 
 
@@ -261,8 +271,16 @@ t_CKUINT MidiOut::progchange( t_CKUINT channel, t_CKUINT patch )
 // desc: chan press
 //-----------------------------------------------------------------------------
 t_CKUINT MidiOut::chanpress( t_CKUINT channel, t_CKUINT pressure )
-{ return this->send( (t_CKBYTE)(MIDI_CHANPRESS + channel), pressure, 0 ); }
+{ return this->send( (t_CKBYTE)(MIDI_CHANPRESS + channel - 1), pressure ); }
 
+
+
+//-----------------------------------------------------------------------------
+// name: pitchbend()
+// desc: pitch bend
+//-----------------------------------------------------------------------------
+t_CKUINT MidiOut::pitchbendFine( t_CKUINT channel, t_CKUINT lsb, t_CKUINT msb)
+{ return this->send( (t_CKBYTE)(MIDI_PITCHBEND + channel - 1), lsb, msb ); }
 
 
 
@@ -271,14 +289,7 @@ t_CKUINT MidiOut::chanpress( t_CKUINT channel, t_CKUINT pressure )
 // desc: pitch bend
 //-----------------------------------------------------------------------------
 t_CKUINT MidiOut::pitchbend( t_CKUINT channel, t_CKUINT bend_val )
-{
-    assert( FALSE );
-    return 0;
-//    return this->send( (t_CKBYTE)(MIDI_PITCHBEND + channel),
-//                       (t_CKBYTE)(HIBYTE( bend_val << 1 )),
-//                       (t_CKBYTE)(LOBYTE( bend_val & 0x7f )) );
-}
-
+{ return this->pitchbendFine( channel, 0, bend_val ); }
 
 
 
@@ -287,10 +298,7 @@ t_CKUINT MidiOut::pitchbend( t_CKUINT channel, t_CKUINT bend_val )
 // desc: allnotesoff
 //-----------------------------------------------------------------------------
 t_CKUINT MidiOut::allnotesoff( t_CKUINT channel )
-{
-    return this->send( (t_CKBYTE)(MIDI_CTRLCHANGE + channel),
-                       (t_CKBYTE)(MIDI_ALLNOTESOFF), 0 );
-}
+{ return this->ctrlchange( channel, 123, 0 ); }
 
 
 

--- a/src/core/midiio_rtmidi.h
+++ b/src/core/midiio_rtmidi.h
@@ -112,6 +112,7 @@ public:
     t_CKUINT ctrlchange( t_CKUINT  channel, t_CKUINT  ctrl_num, t_CKUINT  ctrl_val );
     t_CKUINT progchange( t_CKUINT  channel, t_CKUINT  patch );
     t_CKUINT chanpress( t_CKUINT  channel, t_CKUINT  pressure );
+    t_CKUINT pitchbendFine( t_CKUINT  channel, t_CKUINT  lsb, t_CKUINT  msb );
     t_CKUINT pitchbend( t_CKUINT  channel, t_CKUINT  bend_val );
     t_CKUINT allnotesoff( t_CKUINT  channel );
 


### PR DESCRIPTION
Expose [channel voice messages](https://midi.org/summary-of-midi-1-0-messages) on MidiOut for convenience. 

Midi channel is not one-based, that's probably how it's expected from the user's perspective, happy to change though.

The two-byte MidiOut::send version was modified to fix a faulty behaviour on macOS. This could be a breaking change, but it's improbable and from what i could tell, this function was unused anyway, so it should be fine.

Will open another PR on chuck-website updating the docs after review changes and merge :)
