### PR TITLE
Create the directory hierarchy necessary to preload the different files.

### DIFF
--- a/src/host-web/chucknode-postjs.js
+++ b/src/host-web/chucknode-postjs.js
@@ -509,8 +509,18 @@ class ChuckNode extends AudioWorkletProcessor
                 {
                     return function()
                     {
-                        // Create a directory for chugins
-                        Module["FS_createPath"]("/", "chugins", true, true);
+                        // Create directories required to load filesToPreload
+                        const dirs = filesToPreload.map((f) => {
+                            const path = f.filename.split("/");
+                            return path.slice(0, path.length - 1);
+                        });
+
+                        dirs.forEach((dir) =>
+                            dir.reduce((parent, name) => {
+                                Module["FS_createPath"](parent, name, true, true);
+                                return parent + "/" + name;
+                            }, '/')
+                        );
 
                         // Preload files into the file system
                         for( var i = 0; i < filesToPreload.length; i++ )


### PR DESCRIPTION
This is an attempt at implementing what I have described [here](https://github.com/ccrma/webchuck/issues/43).

I suspect that my modifications make the lines creating the `chugins` directory redundant, but I am unsure, and couldn't test it as I am a beginner with chuck and am not yet familiar with chugins.

Let me know, how I can improve this PR.