### PR TITLE
improve GC behavior for UGens; fix SndBuf FD cleanup

### DIFF
--- a/VERSIONS
+++ b/VERSIONS
@@ -8,6 +8,16 @@ ChucK VERSIONS log
     specified paths; instead the specified paths are added to the import 
     system user paths, and the .chug and .ck files within the specified 
     paths can be @imported.
+(updated) improved internal garbage collection mechanism for all UGens; 
+    now UGens are garbage collected and disconnected from all its UGen 
+    connections, as soon as it is now longer referenced from code (previously,
+    this was deferred until the end of origin shred the UGen was created on,
+    which poses potentially significant memory build-up if a shred repeatedly
+    instantiated/connected UGens without exiting). Overall, this internal
+    update should result in improved CPU performance and memory behavior in 
+    various scenarios.
+(fixed) long-standing SndBuf issue, especially prevalent on macOS:
+    "System error : Too many open files." this was due a combination of 
 (added) --auto-load-chugin-path:<path> flag -- this behaves as 
     --chugin-path previously did: chugins in the specified path(s) are 
     auto-loaded; .ck files can be @imported

--- a/src/core/chuck_instr.cpp
+++ b/src/core/chuck_instr.cpp
@@ -4381,7 +4381,8 @@ t_CKBOOL initialize_object( Chuck_Object * object, Chuck_Type * type, Chuck_VM_S
     // REFACTOR-2017: added | 1.5.1.5 (ge & andrew) moved here from instantiate_...
     object->setOriginVM( vm );
     // set origin shred for non-ugens | 1.5.1.5 (ge & andrew) moved here from instantiate_...
-    if( !type->ugen_info && setShredOrigin ) object->setOriginShred( shred );
+    // remove dependency on non-ugens | 1.5.4.2 (ge) part of #ugen-refs
+    if( /* !type->ugen_info && */ setShredOrigin ) object->setOriginShred( shred );
 
     // allocate virtual table
     object->vtable = new Chuck_VTable;
@@ -4410,15 +4411,21 @@ t_CKBOOL initialize_object( Chuck_Object * object, Chuck_Type * type, Chuck_VM_S
     {
         // ugen
         Chuck_UGen * ugen = (Chuck_UGen *)object;
+        //---------------------------------------
         // UGens: needs shred for auto-disconnect when shred is removed
         // 1.5.1.5 (ge & andrew) moved from instantiate_and_initialize_object()
-        if( shred )
-        {
-            // add ugen to shred (ref-counted)
-            shred->add( ugen );
-            // add shred to ugen (ref-counted) | 1.5.1.5 (ge) was: ugen->shred = shred;
-            object->setOriginShred( shred );
-        }
+        // if( shred )
+        // {
+        //    // add ugen to shred (ref-counted)
+        //    shred->add( ugen );
+        //    // add shred to ugen (ref-counted) | 1.5.1.5 (ge) was: ugen->shred = shred;
+        //    object->setOriginShred( shred );
+        // }
+        //---------------------------------------
+        // 1.5.4.2 (ge) revisiting the above mechanism, part of #ugen-refs
+        // now UGens are not ref-counted by shred, is subject to the normal GC,
+        // and when refcount goes to 0, will remove it self from UGen graph
+        //---------------------------------------
         // set tick
         if( type->ugen_info->tick ) ugen->tick = type->ugen_info->tick;
         // added 1.3.0.0 -- tickf for multi-channel tick

--- a/src/core/chuck_lang.cpp
+++ b/src/core/chuck_lang.cpp
@@ -209,6 +209,12 @@ t_CKBOOL init_class_ugen( Chuck_Env * env, Chuck_Type * type )
     func->doc = "get the ugen's buffered operation mode.";
     if( !type_engine_import_mfun( env, func ) ) goto error;
 
+//    // add attachToOriginShred
+//    func = make_new_mfun( "Shred", "attachToOriginShred", ugen_originShred );
+//    func->add_arg( "Shred", "shred" );
+//    func->doc = "(Use with care) by default, a UGen is attached to its origin Shred (the Shred the UGen was created on); if that Shred is removed (e.g., by Machine.remove()), it will disconnect its UGens' audio connections. This methods makes it possible for UGen to be attached to either a different Shred or to no Shred if `null` is passed in. The latter makes this UGen a kind of \"free agent\" that is subject to the garbage collector as usual, but no longer to a origin Shred. This is useful ";
+//    if( !type_engine_import_mfun( env, func ) ) goto error;
+
     // end
     type_engine_import_class_end( env );
 

--- a/src/core/ugen_xxx.cpp
+++ b/src/core/ugen_xxx.cpp
@@ -3042,6 +3042,15 @@ struct sndbuf_data
 
     ~sndbuf_data()
     {
+        // open file descriptor? | 1.5.4.2 (ge) added
+        if( this->fd )
+        {
+            // close file descriptor
+            sf_close( this->fd );
+            // zero out
+            this->fd = NULL;
+        }
+
         CK_SAFE_DELETE_ARRAY( buffer );
 
         if( chunk_map )

--- a/src/core/ugen_xxx.cpp
+++ b/src/core/ugen_xxx.cpp
@@ -3042,7 +3042,7 @@ struct sndbuf_data
 
     ~sndbuf_data()
     {
-        // open file descriptor? | 1.5.4.2 (ge) added
+        // open file descriptor? | 1.5.4.2 (ge) added #ugen-refs
         if( this->fd )
         {
             // close file descriptor


### PR DESCRIPTION
1) UGens are still associated with origin shreds BUT are no longer reference counted by origin shreds
2) remove all reference counting from UGen connection => and =^
3) depend on the normal garbage collection to clean up UGen references in the code
4) when UGen variables go out of scope (and refcount goes to 0), also disconnect itself from the UGen graph
5) when a Shred is removed, it will detach associated UGens as before (minus ref-counting)

Now UGens are garbage collected and disconnected from all its UGen onnections, as soon as it is now longer referenced from code (previously, this was deferred until the end of origin shred the UGen was created on, which poses potentially significant memory build-up if a shred repeatedly instantiated/connected UGens without exiting). Overall, this internal update should result in improved CPU performance and memory behavior in various scenarios.
