### PR TITLE
add code coverage report make option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,10 @@ xcshareddata/
 .vscode
 .vs
 chuck.vcxproj.user
+
+# code coverage
+*.gcov
+*.gcda
+*.gcno
+*.info
+/report/

--- a/src/core/makefile
+++ b/src/core/makefile
@@ -18,6 +18,13 @@ LD=g++
 
 CFLAGS+=-I. -Ilo
 
+ifneq ($(COVERAGE_REPORT),)
+CFLAGS+=-fprofile-arcs
+CFLAGS+=-ftest-coverage
+LDFLAGS+=-lgcov
+LDFLAGS+=--coverage
+endif
+
 ifneq ($(CHUCK_STAT),)
 CFLAGS+= -D__CHUCK_STAT_TRACK__
 endif

--- a/src/makefile
+++ b/src/makefile
@@ -105,6 +105,16 @@ LD=$(CXX)
 # note: to compile with a specific c++ version (e.g., c++11) add: -std=c++11
 CFLAGS+=-I. -I$(CK_CORE_DIR) -I$(CK_CORE_DIR)/lo
 
+# Code coverage
+
+# enable chuck debug macros?
+ifneq ($(COVERAGE_REPORT),)
+CFLAGS+=-fprofile-arcs
+CFLAGS+=-ftest-coverage
+LDFLAGS+=-lgcov
+LDFLAGS+=--coverage
+endif
+
 # track stats?
 ifneq ($(CHUCK_STAT),)
 CFLAGS+= -D__CHUCK_STAT_TRACK__
@@ -279,6 +289,12 @@ $(CXXOBJS_HOST): %.o: %.cpp
 test:
 	@make -C test
 
+###################### GENERATE CODE COVERAGE REPORT ###########################
+.PHONY: coverage
+coverage: test
+	lcov --capture --directory . --output-file coverage.info
+	genhtml coverage.info --output-directory report
+
 
 ####################### GENERATE API DOCUMENTATION ############################
 .PHONY: doc ckdoc
@@ -333,7 +349,8 @@ clean-src:
 	$(CK_CORE_DIR)/chuck.tab.h $(CK_CORE_DIR)/chuck.tab.c $(CK_CORE_DIR)/chuck.yy.c \
 	$(DIST_ROOT)/$(DIST_DIR) $(DIST_ROOT)/$(DIST_DIR){,.tgz,.zip} \
 	host-web/webchuck/js/webchuck.js host-web/webchuck/js/webchuck.wasm \
-	Release Debug
+	Release Debug \
+	@rf -rf report/ */*.gcov */*.gcda */*.gcno */*.info
 
 .PHONY: clean
 clean: clean-src


### PR DESCRIPTION
The `COVERAGE_REPORT` option will set the proper build/linking options to track code coverage and the `make coverage` command will then generate a coverage report from the unit tests. 

example usage:
```
> make linux-all -j COVERAGE_REPORT=true
> make coverage
```

And it will spit out some nice htmls pages of our test coverage in the `report/` directory.

Note: this add dependencies on `gcov` and `lcov` to generate the coverage reports, but will not affect building if you don't set teh `COVERAGE_REPORT` flag.