### PR TITLE
add '*.os' to .gitignore to exclude object files from builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.d
 *.o
+*.os
 
 /src/chuck
 /src/core/chuck.output


### PR DESCRIPTION
I'm building the Chodot plugin for the Godot game engine, and when I build on my mac with SCons, all the .os source files still show up in my changelists. This line fixed it right up.