### PR TITLE
feat: low level byte midi api

### DIFF
--- a/examples/midi/midi-bytes-receive.ck
+++ b/examples/midi/midi-bytes-receive.ck
@@ -1,0 +1,19 @@
+MidiIn min;
+
+if (!min.open(0)) {
+	me.exit();
+}
+
+int bytes[0];
+
+while (min => now) {
+	while (min.recv(bytes)) {
+		chout <= "bytes: ";
+
+		for (auto byte : bytes) {
+			chout <= byte <= " ";
+		}
+
+		chout <= IO.newline();
+	}
+}

--- a/examples/midi/midi-bytes-send.ck
+++ b/examples/midi/midi-bytes-send.ck
@@ -1,0 +1,10 @@
+MidiOut mout;
+
+if (!mout.open(0)) {
+	me.exit();
+}
+
+// Full frame midi time code (MTC) message.
+// SMPTE timecode: 01:02:03:04.20 (1 hour, 2 minutes, 3 seconds, 4 frames, 20 subframes).
+// F0 7F 7F 01 01 01 02 03 04 14 F7
+mout.send([ 0xF0, 0x7F, 0x7F, 0x01, 0x01, 0x01, 0x02, 0x03, 0x04, 0x14, 0xF7 ]);

--- a/src/core/chuck_io.cpp
+++ b/src/core/chuck_io.cpp
@@ -811,7 +811,7 @@ t_CKBOOL init_class_Midi( Chuck_Env * env )
     // add recv()
     func = make_new_mfun( "int", "recv", MidiIn_recv_bytes );
     func->add_arg( "int[]", "bytes" );
-    func->doc = "Return into the MidiMsg argument the next message in the queue from the device. Return 0 if the queue is empty or 1 if a message was in the queue and returned in the argument.";
+    func->doc = "Return into the int[] argument the next message in the queue from the device. Return 0 if the queue is empty or 1 if a message was in the queue and returned in the argument.";
     if( !type_engine_import_mfun( env, func ) ) goto error;
 
 
@@ -2487,43 +2487,26 @@ CK_DLL_MFUN( MidiIn_recv )
 {
     MidiIn * min = (MidiIn *)OBJ_MEMBER_INT(SELF, MidiIn_offset_data);
     Chuck_Object * fake_msg = GET_CK_OBJECT(ARGS);
-    Chuck_ArrayInt bytes(false, 3);
-    RETURN->v_int = min->recv( &bytes );
+    MidiMsg the_msg;
+    RETURN->v_int = min->recv( &the_msg );
     if( RETURN->v_int )
     {
-        t_CKUINT val;
-
-        bytes.get(0, &val);
-        OBJ_MEMBER_INT(fake_msg, MidiMsg_offset_data1) = val;
-        bytes.get(1, &val);
-        OBJ_MEMBER_INT(fake_msg, MidiMsg_offset_data2) = val;
-        bytes.get(2, &val);
-        OBJ_MEMBER_INT(fake_msg, MidiMsg_offset_data3) = val;
+        OBJ_MEMBER_INT(fake_msg, MidiMsg_offset_data1) = the_msg.data[0];
+        OBJ_MEMBER_INT(fake_msg, MidiMsg_offset_data2) = the_msg.data[1];
+        OBJ_MEMBER_INT(fake_msg, MidiMsg_offset_data3) = the_msg.data[2];
     }
 }
-
-// CK_DLL_MFUN( MidiIn_recv )
-// {
-//     MidiIn * min = (MidiIn *)OBJ_MEMBER_INT(SELF, MidiIn_offset_data);
-//     Chuck_Object * fake_msg = GET_CK_OBJECT(ARGS);
-//     MidiMsg the_msg;
-//     RETURN->v_int = min->recv( &the_msg );
-//     if( RETURN->v_int )
-//     {
-//         OBJ_MEMBER_INT(fake_msg, MidiMsg_offset_data1) = the_msg.data[0];
-//         OBJ_MEMBER_INT(fake_msg, MidiMsg_offset_data2) = the_msg.data[1];
-//         OBJ_MEMBER_INT(fake_msg, MidiMsg_offset_data3) = the_msg.data[2];
-//     }
-// }
 
 CK_DLL_MFUN( MidiIn_recv_bytes )
 {
     MidiIn * min = (MidiIn *)OBJ_MEMBER_INT(SELF, MidiIn_offset_data);
     Chuck_ArrayInt * bytes = (Chuck_ArrayInt *)GET_NEXT_OBJECT(ARGS);
-    if (bytes == NULL) {
+    if( bytes == NULL )
+    {
         RETURN->v_int = 0;
     }
-    else {
+    else
+    {
         RETURN->v_int = min->recv( bytes );
     }
 }

--- a/src/core/chuck_io.cpp
+++ b/src/core/chuck_io.cpp
@@ -2521,24 +2521,13 @@ CK_DLL_MFUN( MidiIn_recv )
 CK_DLL_MFUN( MidiIn_recv_bytes )
 {
     MidiIn * min = (MidiIn *)OBJ_MEMBER_INT(SELF, MidiIn_offset_data);
-    Chuck_ArrayInt * bytes = (Chuck_ArrayInt *)GET_CK_OBJECT(ARGS);
-
-    if( bytes == NULL )
-    {
-        // assing a new array to the pointer
-        bytes = new Chuck_ArrayInt( FALSE );
-        initialize_object( bytes, SHRED->vm_ref->env()->ckt_array, SHRED, VM );
+    Chuck_ArrayInt * bytes = (Chuck_ArrayInt *)GET_NEXT_OBJECT(ARGS);
+    if (bytes == NULL) {
+        RETURN->v_int = 0;
     }
-
-    RETURN->v_int = min->recv( bytes );
-    // Chuck_Object * fake_msg = GET_CK_OBJECT(ARGS);
-    // Chuck_ArrayInt * bytes = (Chuck_ArrayInt *)OBJ_MEMBER_INT(fake_msg, MidiMsg_offset_bytes);
-    // if( RETURN->v_int )
-    // {
-    //     OBJ_MEMBER_INT(fake_msg, MidiMsg_offset_data1) = bytes->m_vector[0];
-    //     OBJ_MEMBER_INT(fake_msg, MidiMsg_offset_data2) = bytes->m_vector[1];
-    //     OBJ_MEMBER_INT(fake_msg, MidiMsg_offset_data3) = bytes->m_vector[2];
-    // }
+    else {
+        RETURN->v_int = min->recv( bytes );
+    }
 }
 
 CK_DLL_MFUN( MidiIn_can_wait )

--- a/src/core/chuck_io.h
+++ b/src/core/chuck_io.h
@@ -476,11 +476,13 @@ CK_DLL_MFUN( cherr_writefloat );
 // MidiMsg API
 //-----------------------------------------------------------------------------
 CK_DLL_CTOR( MidiMsg_ctor );
+CK_DLL_DTOR( MidiMsg_dtor );
 
 extern t_CKUINT MidiMsg_offset_data1;
 extern t_CKUINT MidiMsg_offset_data2;
 extern t_CKUINT MidiMsg_offset_data3;
 extern t_CKUINT MidiMsg_offset_when;
+extern t_CKUINT MidiMsg_offset_bytes;
 
 #ifndef __DISABLE_MIDI__
 //-----------------------------------------------------------------------------
@@ -544,6 +546,7 @@ CK_DLL_MFUN( MidiOut_name );
 CK_DLL_MFUN( MidiOut_printerr );
 CK_DLL_MFUN( MidiOut_send );
 CK_DLL_MFUN( MidiOut_send_msg );
+CK_DLL_MFUN( MidiOut_send_bytes );
 CK_DLL_MFUN( MidiOut_noteOn );
 CK_DLL_MFUN( MidiOut_noteOff );
 CK_DLL_MFUN( MidiOut_controlChange );

--- a/src/core/chuck_io.h
+++ b/src/core/chuck_io.h
@@ -529,6 +529,7 @@ CK_DLL_MFUN( MidiIn_num );
 CK_DLL_MFUN( MidiIn_name );
 CK_DLL_MFUN( MidiIn_printerr );
 CK_DLL_MFUN( MidiIn_recv );
+CK_DLL_MFUN( MidiIn_recv_bytes );
 CK_DLL_MFUN( MidiIn_can_wait );
 
 

--- a/src/core/chuck_io.h
+++ b/src/core/chuck_io.h
@@ -476,13 +476,11 @@ CK_DLL_MFUN( cherr_writefloat );
 // MidiMsg API
 //-----------------------------------------------------------------------------
 CK_DLL_CTOR( MidiMsg_ctor );
-CK_DLL_DTOR( MidiMsg_dtor );
 
 extern t_CKUINT MidiMsg_offset_data1;
 extern t_CKUINT MidiMsg_offset_data2;
 extern t_CKUINT MidiMsg_offset_data3;
 extern t_CKUINT MidiMsg_offset_when;
-extern t_CKUINT MidiMsg_offset_bytes;
 
 #ifndef __DISABLE_MIDI__
 //-----------------------------------------------------------------------------

--- a/src/core/midiio_rtmidi.cpp
+++ b/src/core/midiio_rtmidi.cpp
@@ -570,7 +570,8 @@ t_CKBOOL MidiInManager::add_vm( Chuck_VM * vm, t_CKINT device_num,
 
     // allocate the buffer
     CBufferAdvanceVariable * cbuf = new CBufferAdvanceVariable;
-    if( !cbuf->initialize( MIDI_BUFFER_SIZE, m_event_buffers[vm] ) )
+    // buffer size with an estimate of 3 bytes per message
+    if( !cbuf->initialize( MIDI_BUFFER_SIZE * 3, m_event_buffers[vm] ) )
     {
         if( !suppress_output )
             EM_error2( 0, "MidiIn: couldn't allocate CBuffer for port %i...", device_num );
@@ -732,7 +733,9 @@ void MidiInManager::cb_midi_input( double deltatime, std::vector<unsigned char> 
             CBufferAdvanceVariable * cbuf = it->second;
 
             if( cbuf != NULL )
+            {
                 cbuf->put( msg->data(), msg->size() );
+            }
         }
     }
 }

--- a/src/core/midiio_rtmidi.cpp
+++ b/src/core/midiio_rtmidi.cpp
@@ -646,46 +646,45 @@ t_CKBOOL MidiIn::empty()
 
 
 //-----------------------------------------------------------------------------
-// name: get()
-// desc: get message
-// -----------------------------------------------------------------------------
+// name: recv()
+// desc: get a 3-byte midi message
+//-----------------------------------------------------------------------------
 t_CKUINT MidiIn::recv( MidiMsg * msg )
 {
     if( !m_valid ) return FALSE;
+
     t_CKUINT size = m_buffer->getNextSize(m_read_index);
-    if (size != 0)
-    {
-        return size;
-    }
+
+    if( size == 0 ) return size;
 
     t_CKBYTE tmp[size];
 
-    std::fill(tmp, tmp + size, 0);
-
     m_buffer->get(&tmp, m_read_index);
+
+    std::fill(msg->data, msg->data + 3, 0);
 
     for (t_CKUINT i = 0; i < size && i < 3; i++)
     {
-        // if (i > 2)
-        // {
-        //     break;
-        // }
         msg->data[i] = tmp[i];
     }
 
     return size;
 }
 
+
+
+
+//-----------------------------------------------------------------------------
+// name: recv()
+// desc: get a midi message of any byte length
+//-----------------------------------------------------------------------------
 t_CKUINT MidiIn::recv( Chuck_ArrayInt * arr )
 {
     if( !m_valid ) return FALSE;
 
     t_CKUINT size = m_buffer->getNextSize(m_read_index);
 
-    if (size == 0)
-    {
-        return size;
-    }
+    if( size == 0 ) return size;
 
     t_CKBYTE tmp[size];
 

--- a/src/core/midiio_rtmidi.cpp
+++ b/src/core/midiio_rtmidi.cpp
@@ -648,38 +648,44 @@ t_CKBOOL MidiIn::empty()
 //-----------------------------------------------------------------------------
 // name: get()
 // desc: get message
-//-----------------------------------------------------------------------------
-// t_CKUINT MidiIn::recv( MidiMsg * msg )
-// {
-//     if( !m_valid ) return FALSE;
-//
-//     t_CKUINT size = m_buffer->nextSize(m_read_index);
-//
-//     if (size == 0)
-//         return size;
-//
-//     t_CKBYTE tmp[size];
-//
-//     m_buffer->get(&tmp, m_read_index);
-//
-//     for (t_CKUINT i = 0; i < size; i++)
-//     {
-//         if (i > 2)
-//             break;
-//         msg->data[i] = tmp[i];
-//     }
-//
-//     return size;
-// }
+// -----------------------------------------------------------------------------
+t_CKUINT MidiIn::recv( MidiMsg * msg )
+{
+    if( !m_valid ) return FALSE;
+    t_CKUINT size = m_buffer->getNextSize(m_read_index);
+    if (size != 0)
+    {
+        return size;
+    }
+
+    t_CKBYTE tmp[size];
+
+    std::fill(tmp, tmp + size, 0);
+
+    m_buffer->get(&tmp, m_read_index);
+
+    for (t_CKUINT i = 0; i < size && i < 3; i++)
+    {
+        // if (i > 2)
+        // {
+        //     break;
+        // }
+        msg->data[i] = tmp[i];
+    }
+
+    return size;
+}
 
 t_CKUINT MidiIn::recv( Chuck_ArrayInt * arr )
 {
     if( !m_valid ) return FALSE;
 
-    t_CKUINT size = m_buffer->nextSize(m_read_index);
+    t_CKUINT size = m_buffer->getNextSize(m_read_index);
 
     if (size == 0)
+    {
         return size;
+    }
 
     t_CKBYTE tmp[size];
 
@@ -688,7 +694,9 @@ t_CKUINT MidiIn::recv( Chuck_ArrayInt * arr )
     arr->clear();
 
     for (t_CKUINT i = 0; i < size; i++)
+    {
         arr->push_back(tmp[i]);
+    }
 
     return size;
 }

--- a/src/core/midiio_rtmidi.cpp
+++ b/src/core/midiio_rtmidi.cpp
@@ -87,6 +87,32 @@ MidiOut::~MidiOut()
 
 //-----------------------------------------------------------------------------
 // name: send()
+// desc: send an array of midi bytes
+//-----------------------------------------------------------------------------
+t_CKUINT MidiOut::send( Chuck_ArrayInt * arr )
+{
+    if( !m_valid ) return 0;
+
+    t_CKINT length = arr->size();
+    t_CKUINT byte;
+
+    m_msg.clear();
+
+    for( int i = 0; i < length; i++ )
+    {
+        arr->get(i, &byte);
+        m_msg.push_back( byte );
+    }
+    mout->sendMessage( &m_msg );
+
+    return length;
+}
+
+
+
+
+//-----------------------------------------------------------------------------
+// name: send()
 // desc: send 1 byte midi message
 //-----------------------------------------------------------------------------
 t_CKUINT MidiOut::send( t_CKBYTE status )
@@ -623,25 +649,46 @@ t_CKBOOL MidiIn::empty()
 // name: get()
 // desc: get message
 //-----------------------------------------------------------------------------
-t_CKUINT MidiIn::recv( MidiMsg * msg )
+// t_CKUINT MidiIn::recv( MidiMsg * msg )
+// {
+//     if( !m_valid ) return FALSE;
+//
+//     t_CKUINT size = m_buffer->nextSize(m_read_index);
+//
+//     if (size == 0)
+//         return size;
+//
+//     t_CKBYTE tmp[size];
+//
+//     m_buffer->get(&tmp, m_read_index);
+//
+//     for (t_CKUINT i = 0; i < size; i++)
+//     {
+//         if (i > 2)
+//             break;
+//         msg->data[i] = tmp[i];
+//     }
+//
+//     return size;
+// }
+
+t_CKUINT MidiIn::recv( Chuck_ArrayInt * arr )
 {
     if( !m_valid ) return FALSE;
 
     t_CKUINT size = m_buffer->nextSize(m_read_index);
 
-    if (size > 0)
-    {
-        t_CKBYTE tmp[size];
+    if (size == 0)
+        return size;
 
-        m_buffer->get(&tmp, m_read_index);
+    t_CKBYTE tmp[size];
 
-        for (t_CKUINT i = 0; i < size; i++)
-        {
-            if (i > 2)
-                break;
-            msg->data[i] = tmp[i];
-        }
-    }
+    m_buffer->get(&tmp, m_read_index);
+
+    arr->clear();
+
+    for (t_CKUINT i = 0; i < size; i++)
+        arr->push_back(tmp[i]);
 
     return size;
 }
@@ -676,10 +723,9 @@ void MidiInManager::cb_midi_input( double deltatime, std::vector<unsigned char> 
              the_bufs[device_num].begin(); it != the_bufs[device_num].end(); it++ )
         {
             CBufferAdvanceVariable * cbuf = it->second;
+
             if( cbuf != NULL )
-            {
                 cbuf->put( msg->data(), msg->size() );
-            }
         }
     }
 }

--- a/src/core/midiio_rtmidi.h
+++ b/src/core/midiio_rtmidi.h
@@ -155,6 +155,7 @@ public:
 
 public:
     t_CKBOOL empty();
+    t_CKUINT recv( MidiMsg * msg );
     t_CKUINT recv( Chuck_ArrayInt * msg );
 
 public:

--- a/src/core/midiio_rtmidi.h
+++ b/src/core/midiio_rtmidi.h
@@ -101,9 +101,11 @@ public:
     { return m_suppress_output; }
 
 public:
+
     t_CKUINT send( t_CKBYTE status );
     t_CKUINT send( t_CKBYTE status, t_CKBYTE data1 );
     t_CKUINT send( t_CKBYTE status, t_CKBYTE data1, t_CKBYTE data2 );
+    t_CKUINT send( Chuck_ArrayInt * arr );
     t_CKUINT send( const MidiMsg * msg );
 
 public:
@@ -153,7 +155,7 @@ public:
 
 public:
     t_CKBOOL empty();
-    t_CKUINT recv( MidiMsg * msg );
+    t_CKUINT recv( Chuck_ArrayInt * msg );
 
 public:
     CBufferAdvanceVariable * m_buffer;

--- a/src/core/midiio_rtmidi.h
+++ b/src/core/midiio_rtmidi.h
@@ -156,7 +156,7 @@ public:
     t_CKUINT recv( MidiMsg * msg );
 
 public:
-    CBufferAdvance * m_buffer;
+    CBufferAdvanceVariable * m_buffer;
     t_CKUINT m_read_index;
     RtMidiIn * min;
     t_CKBOOL m_valid;
@@ -193,7 +193,7 @@ protected:
     static t_CKBOOL add_vm( Chuck_VM * vm, t_CKINT device_num, t_CKBOOL suppress_output );
 
     static std::vector<RtMidiIn *> the_mins;
-    static std::vector< std::map< Chuck_VM *, CBufferAdvance * > > the_bufs;
+    static std::vector< std::map< Chuck_VM *, CBufferAdvanceVariable * > > the_bufs;
 
 public:
     static std::map< Chuck_VM *, CBufferSimple * > m_event_buffers;

--- a/src/core/util_buffers.cpp
+++ b/src/core/util_buffers.cpp
@@ -421,9 +421,8 @@ void CBufferAdvanceVariable::put( void * data, UINT__ size )
         m_write_offset++;
 
         if ( m_write_offset >= m_buffer_size )
-        {
             m_write_offset = 0;
-        }
+
         m_data[m_write_offset] = d[i];
     }
 
@@ -456,9 +455,7 @@ UINT__ CBufferAdvanceVariable::nextSize( UINT__ read_offset_index )
     SINT__ m_read_offset = m_read_offsets[read_offset_index].read_offset;
 
     if( m_read_offset == m_write_offset )
-    {
         return 0;
-    }
 
     // get the size of the next messages
     return m_data[m_read_offset];
@@ -491,9 +488,8 @@ UINT__ CBufferAdvanceVariable::get( void * data, UINT__ read_offset_index )
         m_read_offset++;
 
         if( m_read_offset >= m_buffer_size )
-        {
             m_read_offset = 0;
-        }
+
         d[i] = m_data[m_read_offset];
     }
 

--- a/src/core/util_buffers.cpp
+++ b/src/core/util_buffers.cpp
@@ -300,17 +300,18 @@ void CBufferAdvance::put( void * data, UINT__ num_elem )
 }*/
 
 
-BOOL__ CBufferAdvance::empty(UINT__ read_offset_index) {
-	// make sure index is valid
-	if (read_offset_index >= m_read_offsets.size())
-		return TRUE;
-	if (m_read_offsets[read_offset_index].read_offset < 0)
-		return TRUE;
+BOOL__ CBufferAdvance::empty(UINT__ read_offset_index)
+{
+    // make sure index is valid
+    if( read_offset_index >= m_read_offsets.size() )
+        return TRUE;
+    if( m_read_offsets[read_offset_index].read_offset < 0 )
+        return TRUE;
 
-	SINT__ m_read_offset = m_read_offsets[read_offset_index].read_offset;
+    SINT__ m_read_offset = m_read_offsets[read_offset_index].read_offset;
 
-	// see if caught up
-	return m_read_offset == m_write_offset;
+    // see if caught up
+    return m_read_offset == m_write_offset;
 }
 
 

--- a/src/core/util_buffers.cpp
+++ b/src/core/util_buffers.cpp
@@ -413,7 +413,7 @@ void CBufferAdvanceVariable::put( void * data, UINT__ size )
     m_mutex.acquire();
     #endif
 
-    // first store the size of the message
+    // store the size of the message
     m_data[m_write_offset] = size;
 
     // copy the data
@@ -433,13 +433,6 @@ void CBufferAdvanceVariable::put( void * data, UINT__ size )
     // possibility of expelling evil shreds
     for( i = 0; i < m_read_offsets.size(); i++ )
     {
-        if( m_write_offset == m_read_offsets[i].read_offset )
-        {
-            // inform shred with index i that it has lost its privileges?
-            // invalidate its read_offset
-            // m_read_offsets[i].read_offset = -1;
-        }
-
         if( m_read_offsets[i].event )
             m_read_offsets[i].event->queue_broadcast( m_event_buffer );
     }
@@ -451,14 +444,15 @@ void CBufferAdvanceVariable::put( void * data, UINT__ size )
 }
 
 
-UINT__ CBufferAdvanceVariable::nextSize( UINT__ read_offset_index )
+UINT__ CBufferAdvanceVariable::getNextSize( UINT__ read_offset_index )
 {
     SINT__ m_read_offset = m_read_offsets[read_offset_index].read_offset;
 
     if( m_read_offset == m_write_offset )
+    {
         return 0;
+    }
 
-    // get the size of the next messages
     return m_data[m_read_offset];
 }
 

--- a/src/core/util_buffers.cpp
+++ b/src/core/util_buffers.cpp
@@ -300,7 +300,7 @@ void CBufferAdvance::put( void * data, UINT__ num_elem )
 }*/
 
 
-BOOL__ CBufferAdvance::empty(UINT__ read_offset_index)
+BOOL__ CBufferAdvance::empty( UINT__ read_offset_index )
 {
     // make sure index is valid
     if( read_offset_index >= m_read_offsets.size() )
@@ -315,19 +315,25 @@ BOOL__ CBufferAdvance::empty(UINT__ read_offset_index)
 }
 
 
-BOOL__ CBufferAdvance::isValidIndex(UINT__ read_offset_index)
+BOOL__ CBufferAdvance::isValidIndex( UINT__ read_offset_index )
 {
     if( read_offset_index >= m_read_offsets.size() )
+    {
         return FALSE;
+    }
 
     SINT__ m_read_offset = m_read_offsets[read_offset_index].read_offset;
 
     if( m_read_offset < 0 )
+    {
         return FALSE;
+    }
 
     // read catch up with write
     if( m_read_offset == m_write_offset )
+    {
         return FALSE;
+    }
 
     return TRUE;
 }

--- a/src/core/util_buffers.cpp
+++ b/src/core/util_buffers.cpp
@@ -405,6 +405,8 @@ void CBufferAdvanceVariable::cleanup()
 
 void CBufferAdvanceVariable::put( void * data, UINT__ size )
 {
+    if( size == 0 ) return;
+
     UINT__ i;
     BYTE__ * d = (BYTE__ *)data;
 

--- a/src/core/util_buffers.cpp
+++ b/src/core/util_buffers.cpp
@@ -300,18 +300,35 @@ void CBufferAdvance::put( void * data, UINT__ num_elem )
 }*/
 
 
-BOOL__ CBufferAdvance::empty( UINT__ read_offset_index )
+BOOL__ CBufferAdvance::empty(UINT__ read_offset_index) {
+	// make sure index is valid
+	if (read_offset_index >= m_read_offsets.size())
+		return TRUE;
+	if (m_read_offsets[read_offset_index].read_offset < 0)
+		return TRUE;
+
+	SINT__ m_read_offset = m_read_offsets[read_offset_index].read_offset;
+
+	// see if caught up
+	return m_read_offset == m_write_offset;
+}
+
+
+BOOL__ CBufferAdvance::isValidIndex(UINT__ read_offset_index)
 {
-    // make sure index is valid
     if( read_offset_index >= m_read_offsets.size() )
-        return TRUE;
-    if( m_read_offsets[read_offset_index].read_offset < 0 )
-        return TRUE;
+        return FALSE;
 
     SINT__ m_read_offset = m_read_offsets[read_offset_index].read_offset;
 
-    // see if caught up
-    return m_read_offset == m_write_offset;
+    if( m_read_offset < 0 )
+        return FALSE;
+
+    // read catch up with write
+    if( m_read_offset == m_write_offset )
+        return FALSE;
+
+    return TRUE;
 }
 
 
@@ -325,15 +342,7 @@ UINT__ CBufferAdvance::get( void * data, UINT__ num_elem, UINT__ read_offset_ind
     m_mutex.acquire();
     #endif
 
-    // make sure index is valid
-    if( read_offset_index >= m_read_offsets.size() )
-    {
-        #ifndef __DISABLE_THREADS__
-        m_mutex.release();
-        #endif
-        return 0;
-    }
-    if( m_read_offsets[read_offset_index].read_offset < 0 )
+    if (!this->isValidIndex(read_offset_index))
     {
         #ifndef __DISABLE_THREADS__
         m_mutex.release();
@@ -342,15 +351,6 @@ UINT__ CBufferAdvance::get( void * data, UINT__ num_elem, UINT__ read_offset_ind
     }
 
     SINT__ m_read_offset = m_read_offsets[read_offset_index].read_offset;
-
-    // read catch up with write
-    if( m_read_offset == m_write_offset )
-    {
-        #ifndef __DISABLE_THREADS__
-        m_mutex.release();
-        #endif
-        return 0;
-    }
 
     // copy
     for( i = 0; i < num_elem; i++ )
@@ -387,6 +387,129 @@ UINT__ CBufferAdvance::get( void * data, UINT__ num_elem, UINT__ read_offset_ind
 }
 
 
+BOOL__ CBufferAdvanceVariable::initialize( UINT__ buffer_size, CBufferSimple * event_buffer )
+{
+    CBufferAdvance::initialize( buffer_size, 1, event_buffer );
+    m_buffer_size = buffer_size;
+    return true;
+}
+
+
+void CBufferAdvanceVariable::cleanup()
+{
+    CBufferAdvance::cleanup();
+    m_buffer_size = 0;
+}
+
+
+void CBufferAdvanceVariable::put( void * data, UINT__ size )
+{
+    UINT__ i;
+    BYTE__ * d = (BYTE__ *)data;
+
+    // TODO: necessary?
+    #ifndef __DISABLE_THREADS__
+    m_mutex.acquire();
+    #endif
+
+    // first store the size of the message
+    m_data[m_write_offset] = size;
+
+    // copy the data
+    for( i = 0; i < size; i++ )
+    {
+        m_write_offset++;
+
+        if ( m_write_offset >= m_buffer_size )
+        {
+            m_write_offset = 0;
+        }
+        m_data[m_write_offset] = d[i];
+    }
+
+    // move to the next write position
+    m_write_offset++;
+
+    // possibility of expelling evil shreds
+    for( i = 0; i < m_read_offsets.size(); i++ )
+    {
+        if( m_write_offset == m_read_offsets[i].read_offset )
+        {
+            // inform shred with index i that it has lost its privileges?
+            // invalidate its read_offset
+            // m_read_offsets[i].read_offset = -1;
+        }
+
+        if( m_read_offsets[i].event )
+            m_read_offsets[i].event->queue_broadcast( m_event_buffer );
+    }
+
+    // TODO: necessary?
+    #ifndef __DISABLE_THREADS__
+    m_mutex.release();
+    #endif
+}
+
+
+UINT__ CBufferAdvanceVariable::nextSize( UINT__ read_offset_index )
+{
+    SINT__ m_read_offset = m_read_offsets[read_offset_index].read_offset;
+
+    if( m_read_offset == m_write_offset )
+    {
+        return 0;
+    }
+
+    // get the size of the next messages
+    return m_data[m_read_offset];
+}
+
+
+UINT__ CBufferAdvanceVariable::get( void * data, UINT__ read_offset_index )
+{
+    UINT__ i;
+    BYTE__ * d = (BYTE__ *)data;
+
+    // TODO: necessary?
+    #ifndef __DISABLE_THREADS__
+    m_mutex.acquire();
+    #endif
+
+    if (!this->isValidIndex(read_offset_index))
+    {
+        #ifndef __DISABLE_THREADS__
+        m_mutex.release();
+        #endif
+        return 0;
+    }
+
+    SINT__ m_read_offset = m_read_offsets[read_offset_index].read_offset;
+    UINT__ size = m_data[m_read_offset];
+
+    for( i = 0; i < size; i++ )
+    {
+        m_read_offset++;
+
+        if( m_read_offset >= m_buffer_size )
+        {
+            m_read_offset = 0;
+        }
+        d[i] = m_data[m_read_offset];
+    }
+
+    m_read_offset++;
+
+    // update read offset at given index
+    m_read_offsets[read_offset_index].read_offset = m_read_offset;
+
+    // TODO: necessary?
+    #ifndef __DISABLE_THREADS__
+    m_mutex.release();
+    #endif
+
+    // return number of elems
+    return size;
+}
 
 
 //-----------------------------------------------------------------------------

--- a/src/core/util_buffers.h
+++ b/src/core/util_buffers.h
@@ -113,14 +113,15 @@ protected:
 
 //-----------------------------------------------------------------------------
 // name: class CBufferAdvanceVariable
-// desc: circular buffer with variable length elements
+// desc: circular buffer with variable length elements - first byte of each
+//       element is the size of the element
 //-----------------------------------------------------------------------------
 class CBufferAdvanceVariable : public CBufferAdvance
 {
 public:
     BOOL__ initialize( UINT__ buffer_size, CBufferSimple * event_buffer = NULL );
+    UINT__ getNextSize( UINT__ read_offset_index );
     UINT__ get( void * data, UINT__ read_offset_index );
-    UINT__ nextSize( UINT__ read_offset_index );
     void put( void * data, UINT__ size );
     void cleanup();
 

--- a/src/core/util_buffers.h
+++ b/src/core/util_buffers.h
@@ -83,6 +83,7 @@ public:
     void resign( UINT__ read_offset_index );
 
 protected:
+    BOOL__ isValidIndex( UINT__ read_offset_index );
     BYTE__ * m_data;
     UINT__   m_data_width;
     //UINT__   m_read_offset;
@@ -110,7 +111,22 @@ protected:
     CBufferSimple * m_event_buffer;
 };
 
+//-----------------------------------------------------------------------------
+// name: class CBufferAdvanceVariable
+// desc: circular buffer with variable length elements
+//-----------------------------------------------------------------------------
+class CBufferAdvanceVariable : public CBufferAdvance
+{
+public:
+    BOOL__ initialize( UINT__ buffer_size, CBufferSimple * event_buffer = NULL );
+    UINT__ get( void * data, UINT__ read_offset_index );
+    UINT__ nextSize( UINT__ read_offset_index );
+    void put( void * data, UINT__ size );
+    void cleanup();
 
+protected:
+    UINT__   m_buffer_size;
+};
 
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This adds support for sysex, mtc and essentially any midi message.

An initial version of this had an extra `.bytes` field added to chuck's `MidiMsg` but that was rather confusing specially for sending out midi, since the same data was represented in multiple places.

This seems like a better design choice, keeping `MidiMsg` as a high level convenience api to cover most of the cases and the byte low level functions `min.recv(int[])` and `mout.send(int[])` for covering any case.

A variable length buffer has to be added for this, implementation is fairly straightforward and seems to be working fine.