### PR TITLE
ChucK Example 4'33".ck

### DIFF
--- a/examples/deep/4'33".ck
+++ b/examples/deep/4'33".ck
@@ -1,0 +1,12 @@
+// 4'33" by John Cage
+// Please reduce buffer size as much as possible
+// Running in terminal? chuck --bufsize:16 4\'33\".ck
+// PiM 10/12/25
+
+//connect audio input to output
+adc => dac;
+//advance time by 4'33"
+4::minute + 33:second => now;
+//disconnect audio with the UnChucK operator
+//adc =< dac;
+adc !=> dac;


### PR DESCRIPTION
Implementation of John Cage's 4'33" in ChucK. Demonstrates UnChucK operator, advancing time, and command line flag `--bufsize(N)`