### PR TITLE
First pass super keyword implementation

### DIFF
--- a/src/core/chuck_emit.cpp
+++ b/src/core/chuck_emit.cpp
@@ -3752,7 +3752,8 @@ t_CKBOOL emit_engine_emit_exp_primary( Chuck_Emitter * emit, a_Exp_Primary exp )
         }
         else if( exp->var == insert_symbol( "super" ) )
         {
-            emit->append( new Chuck_Instr_Reg_Push_Super( emit->env->class_def->parent_type ) );
+            // super is still the same pointer, just different semantics on virtual table lookup
+            emit->append( new Chuck_Instr_Reg_Push_This );
         }
         else if( exp->var == insert_symbol( "me" ) )
         {
@@ -4841,9 +4842,6 @@ t_CKBOOL emit_engine_emit_exp_dot_member( Chuck_Emitter * emit,
             {
                 // emit the base
                 if( !emit_engine_emit_exp( emit, member->base ) ) { return FALSE; }
-                // check if the last instruction was super (as opposed to this)
-                // (niccolo) this seems like not the right way to do this but it works
-                const auto* super_instr = dynamic_cast<Chuck_Instr_Reg_Push_Super*>(emit->code->code.back());
                 // check if we are part of a function call vs. function as value
                 // 1.5.4.3 (ge) added as part of #2024-func-call-update
                 if( member->self->emit_as_funccall )
@@ -4854,14 +4852,21 @@ t_CKBOOL emit_engine_emit_exp_dot_member( Chuck_Emitter * emit,
                 // find the offset for virtual table
                 offset = func->vt_index;
                 // emit the function
-                if (super_instr)
+                // check if the base was `super` | (niccolo, modified by nick and ge) 1.5.5.6
+                if( member->base->s_type == ae_exp_primary &&
+                    member->base->primary.s_type == ae_primary_var &&
+                    member->base->primary.var == insert_symbol( "super" ) )
                 {
-                    emit->append( instr = new Chuck_Instr_Dot_Member_Func_Super( offset, super_instr->type() ) );
+                    // FYI is the base is super, then the pointer on the stack is the SAME...
+                    // but the vtable lookup logic must be different, hence this instruction
+                    emit->append( instr = new Chuck_Instr_Dot_Member_Func_Super( offset, emit->env->class_def->parent_type ) );
                 }
                 else
                 {
+                    // function lookup with "this" semantics
                     emit->append( instr = new Chuck_Instr_Dot_Member_Func( offset ) );
                 }
+                // set line position
                 instr->set_linepos( member->line );
             }
             else

--- a/src/core/chuck_instr.cpp
+++ b/src/core/chuck_instr.cpp
@@ -2565,22 +2565,6 @@ void Chuck_Instr_Reg_Push_This::execute( Chuck_VM * vm, Chuck_VM_Shred * shred )
 // name: execute()
 // desc: ...
 //-----------------------------------------------------------------------------
-void Chuck_Instr_Reg_Push_Super::execute( Chuck_VM * vm, Chuck_VM_Shred * shred )
-{
-    t_CKUINT *& reg_sp = (t_CKUINT *&)shred->reg->sp;
-    t_CKUINT *& mem_sp = (t_CKUINT *&)shred->mem->sp;
-
-    // push val into reg stack
-    push_( reg_sp, *(mem_sp) );
-}
-
-
-
-
-//-----------------------------------------------------------------------------
-// name: execute()
-// desc: ...
-//-----------------------------------------------------------------------------
 void Chuck_Instr_Reg_Push_Start::execute( Chuck_VM * vm, Chuck_VM_Shred * shred )
 {
     t_CKTIME *& reg_sp = (t_CKTIME *&)shred->reg->sp;
@@ -7776,7 +7760,7 @@ error:
 
 //-----------------------------------------------------------------------------
 // name: execute()
-// desc: ...
+// desc: call super class member function | 1.5.5.6 (niccolo) added
 //-----------------------------------------------------------------------------
 void Chuck_Instr_Dot_Member_Func_Super::execute( Chuck_VM * vm, Chuck_VM_Shred * shred )
 {
@@ -7812,8 +7796,11 @@ error:
     shred->is_done = TRUE;
 }
 
+
+
+
 //-----------------------------------------------------------------------------
-// name: get_func()
+// name: get_func() | 1.5.5.6 (niccolo) added
 // desc: recursively, move up until the function from the correct type is found
 //-----------------------------------------------------------------------------
 Chuck_Func * Chuck_Instr_Dot_Member_Func_Super::get_func( Chuck_Object * obj ) const
@@ -7821,8 +7808,9 @@ Chuck_Func * Chuck_Instr_Dot_Member_Func_Super::get_func( Chuck_Object * obj ) c
     // current func and type
     Chuck_Func * func = obj->vtable->funcs[m_offset];
     // move up until the type matches, or we it can no longer go up
-    while( func->value_ref->owner_class != m_type && func->up )
+    while( !equals( func->value_ref->owner_class, m_type) && func->up )
     {
+        // super class function
         func = func->up->owner->obj_v_table.funcs[m_offset];
     }
     return func;

--- a/src/core/chuck_instr.h
+++ b/src/core/chuck_instr.h
@@ -2337,27 +2337,6 @@ public:
 
 
 //-----------------------------------------------------------------------------
-// name: struct Chuck_Instr_Reg_Push_Super
-// desc: push value of super (this) to reg stack
-//-----------------------------------------------------------------------------
-struct Chuck_Instr_Reg_Push_Super : public Chuck_Instr
-{
-public:
-    Chuck_Instr_Reg_Push_Super( const Chuck_Type* type )
-    { m_type = type; }
-    
-public:
-    virtual void execute( Chuck_VM * vm, Chuck_VM_Shred * shred );
-    const Chuck_Type * type() const { return m_type; }
-    
-protected:
-    const Chuck_Type * m_type;
-};
-
-
-
-
-//-----------------------------------------------------------------------------
 // name: struct Chuck_Instr_Reg_Push_Start
 // desc: push value of start to reg stack
 //-----------------------------------------------------------------------------
@@ -3823,25 +3802,26 @@ protected:
 
 
 //-----------------------------------------------------------------------------
-// name: struct Chuck_Instr_Dot_Member_Func_Super
+// name: struct Chuck_Instr_Dot_Member_Func_Super | 1.5.5.6 (niccolo) added
 // desc: access the super member function of object by offset and type
 //-----------------------------------------------------------------------------
 struct Chuck_Instr_Dot_Member_Func_Super : public Chuck_Instr
 {
 public:
-    Chuck_Instr_Dot_Member_Func_Super( t_CKUINT offset, const Chuck_Type* type )
+    Chuck_Instr_Dot_Member_Func_Super( t_CKUINT offset, const Chuck_Type * type )
     { m_offset = offset; m_type = type; }
 
 public:
     virtual void execute( Chuck_VM * vm, Chuck_VM_Shred * shred );
     virtual const char * params() const
     { static char buffer[CK_PRINT_BUF_LENGTH];
-      snprintf( buffer, CK_PRINT_BUF_LENGTH, "offset=%ld", (long)m_offset );
+      snprintf( buffer, CK_PRINT_BUF_LENGTH, "offset=%ld super='%s'",
+                (long)m_offset, m_type ? m_type->base_name.c_str() : "[NULL]" );
       return buffer; }
 
 protected:
     t_CKUINT m_offset;
-    const Chuck_Type* m_type;
+    const Chuck_Type * m_type; // not const so we can get name
     Chuck_Func * get_func( Chuck_Object * obj ) const;
 };
 

--- a/src/core/chuck_type.cpp
+++ b/src/core/chuck_type.cpp
@@ -3632,7 +3632,7 @@ t_CKTYPE type_engine_check_exp_primary( Chuck_Env * env, a_Exp_Primary exp )
                 // whatever the class is
                 t = env->class_def;
             }
-            else if( str == "super" )
+            else if( str == "super" ) // 1.5.5.6 (niccolo) added
             {
                 // in class def
                 if( !env->class_def )
@@ -3650,11 +3650,11 @@ t_CKTYPE type_engine_check_exp_primary( Chuck_Env * env, a_Exp_Primary exp )
                     return NULL;
                 }
                 
-                // class extends another class
-                if ( env->class_def->parent_type->base_name == "Object" )
-                {   
+                // class is the base Object class
+                if( env->class_def->base_name == "Object" )
+                {
                     EM_error2( exp->where,
-                        "keyword 'super' cannot be used in a class that doesn't extend" );
+                        "keyword 'super' cannot be used from within the Object class" );
                     return NULL;
                 }
 
@@ -6316,7 +6316,7 @@ t_CKBOOL operator !=( const Chuck_Type & lhs, const Chuck_Type & rhs )
 // name: equals()
 // desc: type equivalence test
 //-----------------------------------------------------------------------------
-t_CKBOOL equals( Chuck_Type * lhs, Chuck_Type * rhs ) { return (*lhs) == (*rhs); }
+t_CKBOOL equals( const Chuck_Type * lhs, const Chuck_Type * rhs ) { return (*lhs) == (*rhs); }
 
 
 

--- a/src/core/chuck_type.h
+++ b/src/core/chuck_type.h
@@ -1363,7 +1363,7 @@ t_CKBOOL type_engine_add_class_from_dl( Chuck_Env * env, Chuck_DL_Class * c );
 t_CKBOOL operator ==( const Chuck_Type & lhs, const Chuck_Type & rhs );
 t_CKBOOL operator !=( const Chuck_Type & lhs, const Chuck_Type & rhs );
 t_CKBOOL operator <=( const Chuck_Type & lhs, const Chuck_Type & rhs );
-t_CKBOOL equals( Chuck_Type * lhs, Chuck_Type * rhs );
+t_CKBOOL equals( const Chuck_Type * lhs, const Chuck_Type * rhs );
 t_CKBOOL isa( const Chuck_Type * lhs, const Chuck_Type * rhs );
 t_CKBOOL isa_levels( const Chuck_Type & lhs, const Chuck_Type & rhs, t_CKUINT & levels ); // 1.5.2.0 (ge) return how many levels of inheritance from lhs to rhs
 t_CKBOOL isprim( Chuck_Env * env, Chuck_Type * type );


### PR DESCRIPTION
"super" keyword implementation, based on the method invocation part of the Java super keyword spec: https://docs.oracle.com/javase/specs/jls/se21/html/jls-15.html#d5e31535

i.e. super.foo() calls the parent version of the function.

Here are the test chuck scripts that I put together for the keyword, including scripts to trigger compile errors and scripts to test the runtime functionality:
[tests.zip](https://github.com/user-attachments/files/23157426/tests.zip)

When possible, I like to have tests that define the spec. Ideally, there would be a more rigorous testing setup that actually asserts outcomes, whereas this just prints output and relies on the user to evaluate the output.

I put this feature together by just reverse engineering the "this" keyword and expanding from there. With that in mind, I think there are some things that probably are not done correctly / optimally. Namely, I think the dynamic_cast to check if the last instruction was "super" seems suspect.