### PR TITLE
Math.sh() Examples

### DIFF
--- a/examples/math/spherical-harmonics.ck
+++ b/examples/math/spherical-harmonics.ck
@@ -1,0 +1,24 @@
+// name: spherical-harmonics.ck
+// desc: explanation of Math.sh() 
+// author: everett m. carpenter
+// date: spring 2026
+
+// three arguments must be given to Math.sh()
+3 => int order; // analogous to block size in the FFT, this determines how many projections upon bases we are calculating
+23.0 => float azimuth; // horizontal angle in degrees (counter clockwise is positive)
+0.0 => float elevation; // vertical angle in degrees (positive is upwards, 90 is north pole, negative downwards, 0 is the equator)
+
+// Math.sh() will return an array of size (order+1)^2
+Math.sh(order, azimuth, elevation) @=> float projections[];
+
+for(int acn; acn < projections.size(); acn++)
+{
+    // due to Math.sh() being writting with ambisonics in mind, projections are returned in Ambisonic Channel Order (ACN)
+    chout <= "ACN: " <= acn;
+    // but the order and degree of a projection are calculable from ACN
+    Math.floor(Math.sqrt(acn)) $ int => int order;
+    acn - order * order - order => int degree;
+
+    // print
+    chout <= " Order: " <= order <= " Degree: " <= degree <= " Value: " <= projections[acn] <= IO.nl();
+}

--- a/examples/spatial/ambisonic-encoding.ck
+++ b/examples/spatial/ambisonic-encoding.ck
@@ -1,0 +1,34 @@
+// name: ambisonic-encoding.ck
+// desc: utilizes an array of Gain to encode a virtual source in nth order ambisonics
+// author: everett m. carpenter
+// date: spring 2026
+
+// NOTE: various orientations exist across ambisonic literature, Math.sh is implemented
+//       so that an azimuth of 0 is directly infront of the listener, and increasing azimuth
+//       will move the projection counterclockwise. additionally, an elevation of 0 is located
+//       on the horizontal plane, -90 degrees equates to the south pole, and 90 degrees the north.
+
+// let's do second order (Math.sh() supports up to 5th)
+2 => int order;
+0.0 => float azimuth; 
+0.0 => float elevation;
+
+// nth order ambisonics requires (n+1)^2 channels for three dimensional encoding
+SinOsc sing(352.0) => Gain encoder[(order+1)*(order+1)] => blackhole;
+
+while(true)
+{
+    Math.sh(order, azimuth, elevation) @=> float sphericalHarmonics[];
+
+    // Math.sh() will return a (n+1)^2 sized array, one value for the projection upon each harmonic
+    for(int i; i < sphericalHarmonics.size(); i++)
+    {
+        sphericalHarmonics[i] => encoder[i].gain;
+    }
+
+    // rotate horizontally
+    15.0 +=> azimuth;
+
+    // wait some time
+    500::ms => now;
+}

--- a/src/core/ulib_math.cpp
+++ b/src/core/ulib_math.cpp
@@ -1435,36 +1435,7 @@ CK_DLL_SFUN( map2_impl )
 
     // std::cerr << v << " " << x1 << " " << y1 << " " << x2 << " " << y2 << std::endl;
     // remap
-    RETURN->v_float = x2 + (v-x1)/(y1-x1)*(y2-x2);
-}
-
-// everett's spherical harmonics
-CK_DLL_SFUN(ck_sh)
-{
-    t_CKINT order = GET_NEXT_INT(ARGS);
-    t_CKFLOAT direction = GET_NEXT_FLOAT(ARGS);
-    t_CKFLOAT elevation = GET_NEXT_FLOAT(ARGS);
-    if (order <= 5)
-    {
-        unsigned size = (order + 1) * (order + 1);
-        float* coord = SH(order, direction, elevation, 0);
-        // Create a float[] array
-        Chuck_DL_Api::Object returnarray = API->object->create(SHRED, API->type->lookup(VM, "float[]"), false);
-        Chuck_ArrayFloat* coordinatearray = (Chuck_ArrayFloat*)returnarray;
-        for (int i = 0; i < size; i++)
-        {
-            API->object->array_float_push_back(coordinatearray, coord[i]);
-        }
-        delete[] coord;
-        coord = nullptr;
-        // Need to cast back to object due to lost inheirtience structure
-        RETURN->v_object = (Chuck_Object*)coordinatearray;
-    }
-    else 
-    {
-        API->vm->throw_exception("Math.sh() : Invalid Order", "Up to 5th order supported", nullptr);
-        RETURN->v_int = 0;
-    }
+    RETURN->v_float = x2 + (v - x1) / (y1 - x1) * (y2 - x2);
 }
 
 // everett's spherical harmonics

--- a/src/core/ulib_math.cpp
+++ b/src/core/ulib_math.cpp
@@ -1437,3 +1437,61 @@ CK_DLL_SFUN( map2_impl )
     // remap
     RETURN->v_float = x2 + (v-x1)/(y1-x1)*(y2-x2);
 }
+
+// everett's spherical harmonics
+CK_DLL_SFUN(ck_sh)
+{
+    t_CKINT order = GET_NEXT_INT(ARGS);
+    t_CKFLOAT direction = GET_NEXT_FLOAT(ARGS);
+    t_CKFLOAT elevation = GET_NEXT_FLOAT(ARGS);
+    if (order <= 5)
+    {
+        unsigned size = (order + 1) * (order + 1);
+        float* coord = SH(order, direction, elevation, 0);
+        // Create a float[] array
+        Chuck_DL_Api::Object returnarray = API->object->create(SHRED, API->type->lookup(VM, "float[]"), false);
+        Chuck_ArrayFloat* coordinatearray = (Chuck_ArrayFloat*)returnarray;
+        for (int i = 0; i < size; i++)
+        {
+            API->object->array_float_push_back(coordinatearray, coord[i]);
+        }
+        delete[] coord;
+        coord = nullptr;
+        // Need to cast back to object due to lost inheirtience structure
+        RETURN->v_object = (Chuck_Object*)coordinatearray;
+    }
+    else 
+    {
+        API->vm->throw_exception("Math.sh() : Invalid Order", "Up to 5th order supported", nullptr);
+        RETURN->v_int = 0;
+    }
+}
+
+// everett's spherical harmonics
+CK_DLL_SFUN( ck_sh )
+{
+    t_CKINT order = GET_NEXT_INT(ARGS);
+    t_CKFLOAT direction = GET_NEXT_FLOAT(ARGS);
+    t_CKFLOAT elevation = GET_NEXT_FLOAT(ARGS);
+    if (order <= 5)
+    {
+        unsigned size = (order + 1) * (order + 1);
+        float* coord = SH(order, direction, elevation, 0);
+        // Create a float[] array
+        Chuck_DL_Api::Object returnarray = API->object->create(SHRED, API->type->lookup(VM, "float[]"), false);
+        Chuck_ArrayFloat* coordinatearray = (Chuck_ArrayFloat*)returnarray;
+        for (int i = 0; i < size; i++)
+        {
+            API->object->array_float_push_back(coordinatearray, coord[i]);
+        }
+        delete[] coord;
+        coord = nullptr;
+        // Need to cast back to object due to lost inheirtience structure
+        RETURN->v_object = (Chuck_Object*)coordinatearray;
+    }
+    else 
+    {
+        API->vm->throw_exception("Math.sh() : Invalid Order", "Up to 5th order supported", nullptr);
+        RETURN->v_int = 0;
+    }
+}

--- a/src/core/ulib_math.cpp
+++ b/src/core/ulib_math.cpp
@@ -581,6 +581,13 @@ DLL_QUERY libmath_query( Chuck_DL_Query * QUERY )
     QUERY->add_svar( QUERY, "complex", "j", TRUE, &g_i );
     QUERY->doc_var( QUERY, "The complex number sqrt(-1)." );
 
+    // spherical harmonics emc:2026
+    QUERY->add_sfun( QUERY, ck_sh, "float[]", "sh" );
+    QUERY->add_arg( QUERY, "int", "order" );
+    QUERY->add_arg( QUERY, "float", "azimuth" );
+    QUERY->add_arg( QUERY, "float", "zenith" );
+    QUERY->doc_func(QUERY, "Returns an array of size (N+1)^2, containing ACN ordered spherical harmonics.");
+
     // add examples
     // QUERY->add_ex( QUERY, "map.ck" );
     // QUERY->add_ex( QUERY, "math-help.ck" );

--- a/src/core/ulib_math.cpp
+++ b/src/core/ulib_math.cpp
@@ -581,8 +581,8 @@ DLL_QUERY libmath_query( Chuck_DL_Query * QUERY )
     QUERY->add_svar( QUERY, "complex", "j", TRUE, &g_i );
     QUERY->doc_var( QUERY, "The complex number sqrt(-1)." );
 
-    // spherical harmonics emc:2026
-    QUERY->add_sfun( QUERY, ck_sh, "float[]", "sh" );
+    // spherical harmonics | (added) 1.5.5.8 by everett 2026
+    QUERY->add_sfun( QUERY, sh_impl, "float[]", "sh" );
     QUERY->add_arg( QUERY, "int", "order" );
     QUERY->add_arg( QUERY, "float", "azimuth" );
     QUERY->add_arg( QUERY, "float", "zenith" );
@@ -1445,32 +1445,35 @@ CK_DLL_SFUN( map2_impl )
     RETURN->v_float = x2 + (v - x1) / (y1 - x1) * (y2 - x2);
 }
 
-// everett's spherical harmonics
-CK_DLL_SFUN( ck_sh )
+// spherical harmonics implementation | (added) 1.5.5.8 by everett 2026
+CK_DLL_SFUN( sh_impl )
 {
     t_CKINT order = GET_NEXT_INT(ARGS);
     t_CKFLOAT direction = GET_NEXT_FLOAT(ARGS);
     t_CKFLOAT elevation = GET_NEXT_FLOAT(ARGS);
-    t_CKFLOAT* coord = new t_CKFLOAT[(order + 1) * (order + 1) + 1];
-    if (order <= 5)
+    t_CKFLOAT * coord = new t_CKFLOAT[(order + 1) * (order + 1) + 1];
+    if( order <= 5 )
     {
-        unsigned size = (order + 1) * (order + 1);
-        SH(coord,order, direction, elevation, 0); // moved memory ownership to ck_sh emc 2/26 (memory was previously allocated by SH() and deleted by ck_sh)
+        t_CKUINT size = (order + 1) * (order + 1);
+        // moved memory ownership to ck_SH emc 2/26 (memory was previously allocated by ck_SH() and deleted by sh_impl)
+        ck_SH( coord,order, direction, elevation, 0 );
         // Create a float[] array
-        Chuck_DL_Api::Object returnarray = API->object->create(SHRED, API->type->lookup(VM, "float[]"), false);
-        Chuck_ArrayFloat* coordinatearray = (Chuck_ArrayFloat*)returnarray;
-        for (int i = 0; i < size; i++)
+        Chuck_DL_Api::Object returnarray = API->object->create( SHRED, API->type->lookup(VM, "float[]"), false );
+        Chuck_ArrayFloat * coordinatearray = (Chuck_ArrayFloat *)returnarray;
+        for( t_CKINT i = 0; i < size; i++ )
         {
             API->object->array_float_push_back(coordinatearray, coord[i]);
         }
-        delete[] coord;
-        coord = nullptr;
-        // Need to cast back to object due to lost inheirtience structure
-        RETURN->v_object = (Chuck_Object*)coordinatearray;
+        // set return value
+        RETURN->v_object = coordinatearray;
     }
     else 
     {
-        API->vm->throw_exception("Math.sh() : Invalid Order", "Up to 5th order supported", nullptr);
+        // throw exception
+        API->vm->throw_exception("Math.sh() : InvalidSHOrder", "only up to 5th order currently supported", nullptr);
         RETURN->v_int = 0;
     }
+
+    // clean up
+    CK_SAFE_DELETE_ARRAY( coord );
 }

--- a/src/core/ulib_math.cpp
+++ b/src/core/ulib_math.cpp
@@ -1451,10 +1451,11 @@ CK_DLL_SFUN( ck_sh )
     t_CKINT order = GET_NEXT_INT(ARGS);
     t_CKFLOAT direction = GET_NEXT_FLOAT(ARGS);
     t_CKFLOAT elevation = GET_NEXT_FLOAT(ARGS);
+    t_CKFLOAT* coord = new t_CKFLOAT[(order + 1) * (order + 1) + 1];
     if (order <= 5)
     {
         unsigned size = (order + 1) * (order + 1);
-        t_CKFLOAT* coord = SH(order, direction, elevation, 0);
+        SH(coord,order, direction, elevation, 0); // moved memory ownership to ck_sh emc 2/26 (memory was previously allocated by SH() and deleted by ck_sh)
         // Create a float[] array
         Chuck_DL_Api::Object returnarray = API->object->create(SHRED, API->type->lookup(VM, "float[]"), false);
         Chuck_ArrayFloat* coordinatearray = (Chuck_ArrayFloat*)returnarray;

--- a/src/core/ulib_math.cpp
+++ b/src/core/ulib_math.cpp
@@ -1454,7 +1454,7 @@ CK_DLL_SFUN( ck_sh )
     if (order <= 5)
     {
         unsigned size = (order + 1) * (order + 1);
-        float* coord = SH(order, direction, elevation, 0);
+        t_CKFLOAT* coord = SH(order, direction, elevation, 0);
         // Create a float[] array
         Chuck_DL_Api::Object returnarray = API->object->create(SHRED, API->type->lookup(VM, "float[]"), false);
         Chuck_ArrayFloat* coordinatearray = (Chuck_ArrayFloat*)returnarray;

--- a/src/core/ulib_math.cpp
+++ b/src/core/ulib_math.cpp
@@ -84,6 +84,8 @@ DLL_QUERY libmath_query( Chuck_DL_Query * QUERY )
     QUERY->add_ex( QUERY, "math/maybe.ck" );
     QUERY->add_ex( QUERY, "math/int-dist.ck" );
     QUERY->add_ex( QUERY, "math/map.ck" );
+    QUERY->add_ex( QUERY, "math/spherical-harmonics.ck" );
+    QUERY->add_ex( QUERY, "spatial/ambisonic-encoding.ck" );
 
     // add abs
     QUERY->add_sfun( QUERY, abs_impl, "int", "abs" );

--- a/src/core/ulib_math.h
+++ b/src/core/ulib_math.h
@@ -119,7 +119,7 @@ CK_DLL_SFUN( euclidean4d_impl );
 CK_DLL_SFUN( map_impl );
 CK_DLL_SFUN( map2_impl );
 
-
-
+// spherical harmonics (everett)
+CK_DLL_SFUN( ck_sh );
 
 #endif

--- a/src/core/ulib_math.h
+++ b/src/core/ulib_math.h
@@ -119,7 +119,7 @@ CK_DLL_SFUN( euclidean4d_impl );
 CK_DLL_SFUN( map_impl );
 CK_DLL_SFUN( map2_impl );
 
-// spherical harmonics (everett)
-CK_DLL_SFUN( ck_sh );
+// spherical harmonics | (added) 1.5.5.8 by everett 2026
+CK_DLL_SFUN( sh_impl );
 
 #endif

--- a/src/core/util_math.cpp
+++ b/src/core/util_math.cpp
@@ -473,24 +473,22 @@ t_CKFLOAT SN3D(const t_CKUINT order, const t_CKINT degree) // calculate SN3D val
 // desc: calculation of spherical harmonics according to some order and normalization
 // author: everett m. carpenter
 //-----------------------------------------------------------------------------
-t_CKFLOAT* SH(const t_CKUINT order_, const t_CKFLOAT azimuth_, const t_CKFLOAT zenith_, const t_CKBOOL n3d) // SH calc
+void SH(t_CKFLOAT* output, const t_CKUINT order_, const t_CKFLOAT azimuth_, const t_CKFLOAT zenith_, const t_CKBOOL n3d) // SH calc
 {
     float azimuth_shift = (azimuth_) * 0.01745329252; // degree 2 rad
     float zenith_shift = (90.f - zenith_) * 0.01745329252;
     float coszeni = cosf(zenith_shift);
     int size = (order_ + 1) * (order_ + 1);
-    t_CKFLOAT* result = new t_CKFLOAT[size + 1]; // end result
     for (int order = 0; order <= (int)order_; order++)
     {
         if (order == 0)
-            result[0] = SN3D(order, 0);
+            output[0] = SN3D(order, 0);
         for (int degree = -order; degree <= order; degree++)
         {
             float n = n3d ? sqrtf(2 * order + 1) * SN3D(order, degree) : SN3D(order, degree); // normalization term if n3d bool = TRUE, return N3D else SN3D
             float p = (associated_legendre((int)abs(degree), (int)order, coszeni));
             float r = (degree < 0) ? sinf(abs(degree) * (azimuth_shift)) : cosf(degree * (azimuth_shift)); // degree positive? Re(exp(i*azimuth*degree)) degree negative? Im(exp(i*azimuth*degree))
-            result[(order * order) + order + degree] = n * p * r;
+            output[(order * order) + order + degree] = n * p * r;
         }
     }
-    return result;
 }

--- a/src/core/util_math.cpp
+++ b/src/core/util_math.cpp
@@ -376,7 +376,7 @@ t_CKFLOAT ck_vec4_magnitude(const t_CKVEC4& v)
 // desc: factorial calculator function
 // author: everett m. carpenter
 //-----------------------------------------------------------------------------
-int factorial(int n)
+t_CKINT factorial(const t_CKINT n)
 {
     if (n > 10) return -1;
     int result = 1;
@@ -392,7 +392,7 @@ int factorial(int n)
 // desc: closed form associated legendre polynomials of some order l
 // author: everett m. carpenter
 //-----------------------------------------------------------------------------
-float associated_legendre(int m, int l, float x)
+t_CKFLOAT associated_legendre(const t_CKINT m, const t_CKINT l, const t_CKFLOAT x)
 {
     // check bounds
     if (l < 0 || l > 5) return 0.0;
@@ -461,7 +461,7 @@ float associated_legendre(int m, int l, float x)
 // desc: normalization calculator for spherical harmonics
 // author: everett m. carpenter
 //-----------------------------------------------------------------------------
-float SN3D(unsigned order, int degree) // calculate SN3D value
+t_CKFLOAT SN3D(const t_CKUINT order, const t_CKINT degree) // calculate SN3D value
 {
     int d = (degree == 0) ? 1 : 0; // kronecker delta
     float ratio = static_cast<float>(factorial(order - abs(degree))) / static_cast<float>(factorial(order + abs(degree))); // ratio of factorials
@@ -473,13 +473,13 @@ float SN3D(unsigned order, int degree) // calculate SN3D value
 // desc: calculation of spherical harmonics according to some order and normalization
 // author: everett m. carpenter
 //-----------------------------------------------------------------------------
-float* SH(unsigned order_, const float azimuth_, const float zenith_, bool n3d) // SH calc
+t_CKFLOAT* SH(const t_CKUINT order_, const t_CKFLOAT azimuth_, const t_CKFLOAT zenith_, const t_CKBOOL n3d) // SH calc
 {
     float azimuth_shift = (azimuth_) * 0.01745329252; // degree 2 rad
     float zenith_shift = (90.f - zenith_) * 0.01745329252;
     float coszeni = cosf(zenith_shift);
     int size = (order_ + 1) * (order_ + 1);
-    float* result = new float[size + 1]; // end result
+    t_CKFLOAT* result = new t_CKFLOAT[size + 1]; // end result
     for (int order = 0; order <= (int)order_; order++)
     {
         if (order == 0)

--- a/src/core/util_math.cpp
+++ b/src/core/util_math.cpp
@@ -366,33 +366,41 @@ t_CKFLOAT ck_vec3_magnitude( const t_CKVEC3 & v )
 // name: ck_vec4_magnitude()
 // desc: magnitude of vec4
 //-----------------------------------------------------------------------------
-t_CKFLOAT ck_vec4_magnitude(const t_CKVEC4& v)
+t_CKFLOAT ck_vec4_magnitude( const t_CKVEC4 & v )
 {
-    return ::sqrt(v.x * v.x + v.y * v.y + v.z * v.z + v.w * v.w);
+    return ::sqrt( v.x * v.x + v.y * v.y + v.z * v.z + v.w * v.w );
 }
 
+
+
+
 //-----------------------------------------------------------------------------
-// name: factorial
-// desc: factorial calculator function
-// author: everett m. carpenter
+// name: ck_factorial32()
+// desc: factorial calculator function (for 32 bit)
+// author: everett m. carpenter | 1.5.5.8
+//         modified for 32-bit (ge, nick)
 //-----------------------------------------------------------------------------
-t_CKINT factorial(const t_CKINT n)
+t_CKINT ck_factorial32( t_CKINT n )
 {
-    if (n > 10) return -1;
-    int result = 1;
-    for (int i = 1; i <= n; i++) 
-    {
-        result = i * result;
-    }
+    // 12! is the largest factorial that can fit in a 32-bit integer
+    if( n < 0 || n > 12 ) return -1;
+
+    t_CKINT result = 1;
+    for( t_CKINT i = 1; i <= n; i++ )
+    { result = i * result; }
+
     return result;
 }
 
+
+
+
 //-----------------------------------------------------------------------------
-// name: associated_legendre() 
+// name: ck_associated_legendre()
 // desc: closed form associated legendre polynomials of some order l
-// author: everett m. carpenter
+// author: everett m. carpenter | 1.5.5.8
 //-----------------------------------------------------------------------------
-t_CKFLOAT associated_legendre(const t_CKINT m, const t_CKINT l, const t_CKFLOAT x)
+t_CKFLOAT ck_associated_legendre( const t_CKINT m, const t_CKINT l, const t_CKFLOAT x )
 {
     // check bounds
     if (l < 0 || l > 5) return 0.0;
@@ -403,90 +411,98 @@ t_CKFLOAT associated_legendre(const t_CKINT m, const t_CKINT l, const t_CKFLOAT 
     float x4 = x2 * x2;  // x^4
     float cf = 1.0 - x2; // pops up in every associated legendre
     float sqrtcf = sqrt(cf);; // also pops up everywhere
-    int absm = abs(m); // assume m is positive, then apply -m case at end
+    t_CKINT absm = abs(m); // assume m is positive, then apply -m case at end
     float result = 0.f;
     float flip = 1.f;
 
-    if (m < 0) flip = pow(-1.0, absm) * (float)(factorial(l - absm) / factorial(l + absm));
+    if (m < 0) flip = (float)(pow(-1.0, absm) * (ck_factorial32(l - absm) / ck_factorial32(l + absm)));
 
     switch (l) // order and absm
     {
-    case(0): { result = 1.0; break; }
-    case(1):
-    {
-        if (absm == 0) { result = x; }
-        else if (absm == 1) { result = -sqrtcf; }
-        break;
+        case(0):
+        { result = 1.0; break; }
+        case(1):
+        {
+            if (absm == 0) { result = x; }
+            else if (absm == 1) { result = -sqrtcf; }
+            break;
+        }
+        case(2):
+        {
+            if (absm == 0) { result = 0.5 * (3.0 * x2 - 1); }
+            else if (absm == 1) { result = -3.0 * x * sqrtcf; }
+            else if (absm == 2) { result = 3.0 * cf; }
+            break;
+        }
+        case(3):
+        {
+            if (absm == 0) { result = 0.5 * (5.0 * x3 - 3.0 * x); }
+            else if (absm == 1) { result = 1.5 * (1.0 - 5.0 * x2) * sqrtcf; }
+            else if (absm == 2) { result = 15.0 * x * cf; }
+            else if (absm == 3) { result = -15.0 * sqrtcf * cf; }
+            break;
+        }
+        case(4):
+        {
+            if (absm == 0) { result = 0.125 * (35.0 * x4 - 30.0 * x2 + 3.0); }
+            else if (absm == 1) { result = -2.5 * (7.0 * x3 - 3.0 * x) * sqrtcf; }
+            else if (absm == 2) { result = 7.5 * (7.0 * x2 - 1) * cf; }
+            else if (absm == 3) { result = -105.0 * x * sqrtcf * cf; }
+            else if (absm == 4) { result = 105.0 * cf * cf; }
+            break;
+        }
+        case(5):
+        {
+            if (absm == 0) { result = 0.125 * (63.0 * x3 * x2 - 70 * x3 + 15 * x); }
+            else if (absm == 1) { result = -1.875 * sqrtcf * (21.0 * x4 - 14 * x2 + 1); }
+            else if (absm == 2) { result = 52.5 * x * cf * (3.0 * x2 - 1.0); }
+            else if (absm == 3) { result = -52.5 * cf * sqrtcf * (9.0 * x2 - 1.0); }
+            else if (absm == 4) { result = 945.0 * x * cf * cf; }
+            else if (absm == 5) { result = -945.0 * sqrtcf * cf * cf; }
+            break;
+        }
     }
-    case(2):
-    {
-        if (absm == 0) { result = 0.5 * (3.0 * x2 - 1); }
-        else if (absm == 1) { result = -3.0 * x * sqrtcf; }
-        else if (absm == 2) { result = 3.0 * cf; }
-        break;
-    }
-    case(3):
-    {
-        if (absm == 0) { result = 0.5 * (5.0 * x3 - 3.0 * x); }
-        else if (absm == 1) { result = 1.5 * (1.0 - 5.0 * x2) * sqrtcf; }
-        else if (absm == 2) { result = 15.0 * x * cf; }
-        else if (absm == 3) { result = -15.0 * sqrtcf * cf; }
-        break;
-    }
-    case(4):
-    {
-        if (absm == 0) { result = 0.125 * (35.0 * x4 - 30.0 * x2 + 3.0); }
-        else if (absm == 1) { result = -2.5 * (7.0 * x3 - 3.0 * x) * sqrtcf; }
-        else if (absm == 2) { result = 7.5 * (7.0 * x2 - 1) * cf; }
-        else if (absm == 3) { result = -105.0 * x * sqrtcf * cf; }
-        else if (absm == 4) { result = 105.0 * cf * cf; }
-        break;
-    }
-    case(5):
-    {
-        if (absm == 0) { result = 0.125 * (63.0 * x3 * x2 - 70 * x3 + 15 * x); }
-        else if (absm == 1) { result = -1.875 * sqrtcf * (21.0 * x4 - 14 * x2 + 1); }
-        else if (absm == 2) { result = 52.5 * x * cf * (3.0 * x2 - 1.0); }
-        else if (absm == 3) { result = -52.5 * cf * sqrtcf * (9.0 * x2 - 1.0); }
-        else if (absm == 4) { result = 945.0 * x * cf * cf; }
-        else if (absm == 5) { result = -945.0 * sqrtcf * cf * cf; }
-        break;
-    }
-    }
+
     return pow(-1.0, m) * result * flip;
 }
 
+
+
+
 //-----------------------------------------------------------------------------
-// name: SN3D
+// name: ck_SN3D
 // desc: normalization calculator for spherical harmonics
-// author: everett m. carpenter
+// author: everett m. carpenter | 1.5.5.8
 //-----------------------------------------------------------------------------
-t_CKFLOAT SN3D(const t_CKUINT order, const t_CKINT degree) // calculate SN3D value
+t_CKFLOAT ck_SN3D( const t_CKUINT order, const t_CKINT degree ) // calculate SN3D value
 {
     int d = (degree == 0) ? 1 : 0; // kronecker delta
-    float ratio = static_cast<float>(factorial(order - abs(degree))) / static_cast<float>(factorial(order + abs(degree))); // ratio of factorials
+    float ratio = static_cast<float>(ck_factorial32(order - abs(degree))) / static_cast<float>(ck_factorial32(order + abs(degree))); // ratio of factorials
     return sqrtf((2.f - d) * ratio);
 }
 
+
+
+
 //-----------------------------------------------------------------------------
-// name: SH()
+// name: ck_SH()
 // desc: calculation of spherical harmonics according to some order and normalization
-// author: everett m. carpenter
+// author: everett m. carpenter | 1.5.5.8
 //-----------------------------------------------------------------------------
-void SH(t_CKFLOAT* output, const t_CKUINT order_, const t_CKFLOAT azimuth_, const t_CKFLOAT zenith_, const t_CKBOOL n3d) // SH calc
+void ck_SH( t_CKFLOAT * output, const t_CKUINT order_, const t_CKFLOAT azimuth_, const t_CKFLOAT zenith_, const t_CKBOOL n3d )
 {
     float azimuth_shift = (azimuth_) * 0.01745329252; // degree 2 rad
     float zenith_shift = (90.f - zenith_) * 0.01745329252;
     float coszeni = cosf(zenith_shift);
-    int size = (order_ + 1) * (order_ + 1);
+    t_CKINT size = (order_ + 1) * (order_ + 1);
     for (int order = 0; order <= (int)order_; order++)
     {
         if (order == 0)
-            output[0] = SN3D(order, 0);
+            output[0] = ck_SN3D(order, 0);
         for (int degree = -order; degree <= order; degree++)
         {
-            float n = n3d ? sqrtf(2 * order + 1) * SN3D(order, degree) : SN3D(order, degree); // normalization term if n3d bool = TRUE, return N3D else SN3D
-            float p = (associated_legendre((int)abs(degree), (int)order, coszeni));
+            float n = n3d ? sqrtf(2 * order + 1) * ck_SN3D(order, degree) : ck_SN3D(order, degree); // normalization term if n3d bool = TRUE, return N3D else SN3D
+            float p = (ck_associated_legendre((int)abs(degree), (int)order, coszeni));
             float r = (degree < 0) ? sinf(abs(degree) * (azimuth_shift)) : cosf(degree * (azimuth_shift)); // degree positive? Re(exp(i*azimuth*degree)) degree negative? Im(exp(i*azimuth*degree))
             output[(order * order) + order + degree] = n * p * r;
         }

--- a/src/core/util_math.h
+++ b/src/core/util_math.h
@@ -112,8 +112,10 @@ t_CKFLOAT ck_vec2_phase( const t_CKVEC2 & v );
 t_CKFLOAT ck_vec3_magnitude( const t_CKVEC3 & v );
 // magnitude of vec4
 t_CKFLOAT ck_vec4_magnitude( const t_CKVEC4 & v );
-
-
+// associated legendre for spherical harmonics (emc 2026)
+float associated_legendre(int m, int l, float x);
+// spherical harmonics (emc 2026)
+float* SH(unsigned order_, const float azimuth_, const float zenith_, bool n3d);
 
 #if defined (__cplusplus) || defined(_cplusplus)
 }

--- a/src/core/util_math.h
+++ b/src/core/util_math.h
@@ -112,10 +112,12 @@ t_CKFLOAT ck_vec2_phase( const t_CKVEC2 & v );
 t_CKFLOAT ck_vec3_magnitude( const t_CKVEC3 & v );
 // magnitude of vec4
 t_CKFLOAT ck_vec4_magnitude( const t_CKVEC4 & v );
-// associated legendre for spherical harmonics (emc 2026)
-t_CKFLOAT associated_legendre( const t_CKINT m, const t_CKINT l, const t_CKFLOAT x );
-// spherical harmonics (emc 2026)
-void SH( t_CKFLOAT* output, const t_CKUINT order_, const t_CKFLOAT azimuth_, const t_CKFLOAT zenith_, const t_CKBOOL n3d );
+// integer factorial (for up to 12! which is the largest factorial that can fit inside a 32-bit integer)
+t_CKINT ck_factorial32( t_CKINT n );
+// associated legendre for spherical harmonics | (added) 1.5.5.8 by everett 2026
+t_CKFLOAT ck_associated_legendre( const t_CKINT m, const t_CKINT l, const t_CKFLOAT x );
+// spherical harmonics | (added) 1.5.5.8 by everett 2026
+void ck_SH( t_CKFLOAT* output, const t_CKUINT order_, const t_CKFLOAT azimuth_, const t_CKFLOAT zenith_, const t_CKBOOL n3d );
 
 #if defined (__cplusplus) || defined(_cplusplus)
 }

--- a/src/core/util_math.h
+++ b/src/core/util_math.h
@@ -115,7 +115,7 @@ t_CKFLOAT ck_vec4_magnitude( const t_CKVEC4 & v );
 // associated legendre for spherical harmonics (emc 2026)
 t_CKFLOAT associated_legendre( const t_CKINT m, const t_CKINT l, const t_CKFLOAT x );
 // spherical harmonics (emc 2026)
-t_CKFLOAT* SH( const t_CKUINT order_, const t_CKFLOAT azimuth_, const t_CKFLOAT zenith_, const t_CKBOOL n3d );
+void SH( t_CKFLOAT* output, const t_CKUINT order_, const t_CKFLOAT azimuth_, const t_CKFLOAT zenith_, const t_CKBOOL n3d );
 
 #if defined (__cplusplus) || defined(_cplusplus)
 }

--- a/src/core/util_math.h
+++ b/src/core/util_math.h
@@ -113,9 +113,9 @@ t_CKFLOAT ck_vec3_magnitude( const t_CKVEC3 & v );
 // magnitude of vec4
 t_CKFLOAT ck_vec4_magnitude( const t_CKVEC4 & v );
 // associated legendre for spherical harmonics (emc 2026)
-float associated_legendre(int m, int l, float x);
+t_CKFLOAT associated_legendre( const t_CKINT m, const t_CKINT l, const t_CKFLOAT x );
 // spherical harmonics (emc 2026)
-float* SH(unsigned order_, const float azimuth_, const float zenith_, bool n3d);
+t_CKFLOAT* SH( const t_CKUINT order_, const t_CKFLOAT azimuth_, const t_CKFLOAT zenith_, const t_CKBOOL n3d );
 
 #if defined (__cplusplus) || defined(_cplusplus)
 }


### PR DESCRIPTION
Adds examples for Math.sh(), including a general explanation of usage in math/ and an example using Gain[] to achieve ambisonic encoding in spatial/

I know spherical harmonic projections have applications in ML, perhaps Math.sh() could be used for something. There could be some fun experiments in ambisonic soundfield analysis with ChAI. Let me know how these examples look, happy to reduce or increase detail, and mockup more stuff related to ambisonics.