### PR TITLE
added get_vtable_offset_args to chugin api

### DIFF
--- a/src/core/chuck_dl.cpp
+++ b/src/core/chuck_dl.cpp
@@ -1673,6 +1673,59 @@ t_CKINT CK_DLL_CALL ck_get_vtable_offset( Chuck_VM * vm, Chuck_Type * t, const c
 }
 
 
+
+//-----------------------------------------------------------------------------
+// name: ck_get_vtable_offset_args()
+// desc: function pointer get_type(), searching for function defintion with
+//       specific args | 1.5.5.9 (nshaheed) added
+//-----------------------------------------------------------------------------
+t_CKINT CK_DLL_CALL ck_get_vtable_offset_args( Chuck_VM * vm, Chuck_Type * t, const char * valueName, Chuck_Type ** args, int num_args )
+{
+    // find the offset for value by name
+    Chuck_Value * value = type_engine_find_value( t, valueName );
+    // value not found
+    if( !value || !value->func_ref ) return -1;
+
+    Chuck_Func * func = value->func_ref;
+
+    // iterate over overloads looking for matching number of args and types
+    while (func) {
+      a_Func_Def func_def = func->def();
+      a_Arg_List arg_list = func_def->arg_list;
+
+      bool type_signature_match = true;
+      int i = 0;
+
+      // size of arg lists must match
+      while( arg_list && i < num_args ) {
+        // types do not match, exit loop
+        if (!isa(args[i], arg_list->type)) {
+          type_signature_match = false;
+          break;
+        }
+
+        arg_list = arg_list->next;
+        i++;
+      }
+
+      // expected more args from func
+      if (i != num_args) type_signature_match = false;
+      // func had too many args
+      if (arg_list) type_signature_match = false;
+
+      // found a match! returning offset...
+      if (type_signature_match) {
+          return func->vt_index;
+      }
+      func = func->next;
+    }
+
+    // was not able to find a match, returning -1
+    return -1;
+}
+
+
+
 //-----------------------------------------------------------------------------
 // add reference count
 //-----------------------------------------------------------------------------
@@ -2818,6 +2871,7 @@ array_vec4_clear( ck_array_vec4_clear )
 Chuck_DL_Api::TypeApi::TypeApi() :
 lookup(ck_type_lookup),
 get_vtable_offset(ck_get_vtable_offset),
+get_vtable_offset_args(ck_get_vtable_offset_args),
 is_equal(ck_type_isequal),
 isa(ck_type_isa),
 callback_on_instantiate(ck_callback_on_instantiate),

--- a/src/core/chuck_dl.h
+++ b/src/core/chuck_dl.h
@@ -1106,6 +1106,8 @@ public:
         Type (CK_DLL_CALL * const lookup)( Chuck_VM *, const char * name );
         // get vtable offset for named function (if overloaded, returns first one); returns < 0 if not found
         t_CKINT (CK_DLL_CALL * const get_vtable_offset)( Chuck_VM *, Type type, const char * funcName );
+        // get vtable offset for named function with specific input arguments (if overloaded, returns first one); returns < 0 if not found
+        t_CKINT (CK_DLL_CALL * const get_vtable_offset_args)( Chuck_VM *, Type type, const char * funcName, Type * args, int num_args);
         // test if two chuck types are equal
         t_CKBOOL (CK_DLL_CALL * const is_equal)(Type lhs, Type rhs);
         // test if lhs is a type of rhs (e.g., SinOsc is a type of UGen)


### PR DESCRIPTION
This lets you find a function definition with a specific argument list (i.e. now you can look for `SinOsc.freq()` when `SinOsc.freq(float f)` is the first in the overload list of `SinOsc.freq`.

Here's an example usage:

```c++
// Call getter function
CK_DLL_SFUN(patch_call) {
  Chuck_Object* obj = (Chuck_Object*)GET_NEXT_OBJECT(ARGS);
  Chuck_String *method = (Chuck_String *)GET_NEXT_STRING(ARGS);

  // Get object to find offset from
  Chuck_DL_Api::Type obj_type = API->object->get_type( obj );
  Chuck_Type * t = (Chuck_Type *)obj_type;

  string method_str = API->object->str(method);

  // Want the getter, so the args list is empty
  Chuck_Type * arg_list[] = {};
  
  // Lookup the specific function definition, normally this would return the setter
  t_CKINT offset =
    API->type->get_vtable_offset_args(VM, obj_type, method_str.c_str(), arg_list, 0);  

  if (offset < 0) {
    string message = "Member function " + method_str + "() not found in object " + string(API->type->base_name(obj_type));
    API->vm->throw_exception("MemberFunctionNotFound", message.c_str(), SHRED);
  }

  Chuck_DL_Arg* arg = new Chuck_DL_Arg();

  Chuck_DL_Return ret =
      API->vm->invoke_mfun_immediate_mode(obj, offset, VM, SHRED, arg, 0);

  RETURN->v_float = ret.v_float;
}

```
